### PR TITLE
feat: dataset fetcher getbyid

### DIFF
--- a/src/lib/dataset-fetcher.integration.test.ts
+++ b/src/lib/dataset-fetcher.integration.test.ts
@@ -60,3 +60,32 @@ describe('search', () => {
     });
   });
 });
+
+describe('getById', () => {
+  it('returns undefined if no dataset matches the ID', async () => {
+    const dataset = await datasetFetcher.getById({id: 'AnIdThatDoesNotExist'});
+
+    expect(dataset).toBeUndefined();
+  });
+
+  it('returns the dataset that matches the ID', async () => {
+    const dataset = await datasetFetcher.getById({
+      id: 'https://archive.example.org/datasets/7',
+    });
+
+    expect(dataset).toStrictEqual({
+      id: 'https://archive.example.org/datasets/7',
+      name: 'Dataset 7',
+      description:
+        'Maecenas quis sem ante. Vestibulum mattis lorem in mauris pulvinar tincidunt. Sed nisi ligula, mattis id vehicula at, faucibus vel quam.',
+      publisher: {
+        id: 'https://archive.example.org/',
+        name: 'Archive',
+      },
+      license: {
+        id: 'http://creativecommons.org/publicdomain/zero/1.0/',
+        name: 'Public Domain',
+      },
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a new method to the DatasetFetcher, `getBydId()`, for retrieving the details of a specific dataset. It's straightforward in implementation - we'll probably have to revisit this at some point (e.g. by calling a better Elasticsearch endpoint or by querying the triplestore).