### PR TITLE
Don't show the facet numbers

### DIFF
--- a/src/app/[locale]/filter-set.tsx
+++ b/src/app/[locale]/filter-set.tsx
@@ -54,7 +54,7 @@ export default function FilterSet({
                 htmlFor={`${title}-${option.id}`}
                 className="ml-3 text-sm text-gray-600"
               >
-                {option.name} ({option.totalCount})
+                {option.name}
               </label>
             </div>
           ))}


### PR DESCRIPTION
There are multiple ways to show numbers by the facets. There is a lot of discussion about these numbers and which numbers are correct. We don't want to spend time on a wrong implementation. And without real datasets, it's hard to choose the correct implementation.

For now, we decided to hide these numbers, because the current implementation brings confusion.