### PR TITLE
Show the number of datasets in the title of the dataset list

### DIFF
--- a/src/app/[locale]/dataset-list.tsx
+++ b/src/app/[locale]/dataset-list.tsx
@@ -113,7 +113,7 @@ export default function DatasetList({initialSearchResult, locale}: Props) {
         <PageHeader>
           <div className="-ml-4 -mt-2 flex flex-wrap items-center justify-between sm:flex-nowrap">
             <div className="ml-4 mt-2">
-              <PageTitle>Dataset browser</PageTitle>
+              <PageTitle>{data?.totalCount} Dataset(s)</PageTitle>
             </div>
             <div>
               <select


### PR DESCRIPTION
With this code, the text will not change if it's plural or not. 

I want to wait for the implementation of next-intl for the page because next-intl has a render function for pluralization.

https://next-intl-docs.vercel.app/docs/usage/messages#rendering-of-messages

I will add this to the scope of #60 