### PR TITLE
Show selected filters

### DIFF
--- a/cypress/global.d.ts
+++ b/cypress/global.d.ts
@@ -1,7 +1,7 @@
 declare namespace Cypress {
   interface Chainable {
     /**
-     * Custom command to select DOM element by data-test attribute.
+     * Custom command to select DOM element by data-testid attribute.
      * @example cy.getBySel('greeting')
      */
     getBySel(

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -10,5 +10,5 @@
 // ***********************************************
 
 Cypress.Commands.add('getBySel', (selector, ...args) => {
-  return cy.get(`[data-test=${selector}]`, ...args);
+  return cy.get(`[data-testid=${selector}]`, ...args);
 });

--- a/src/app/[locale]/client-search-dataset.ts
+++ b/src/app/[locale]/client-search-dataset.ts
@@ -1,7 +1,7 @@
 import {SearchResult} from '@/lib/dataset-fetcher';
-import {Sort} from './dataset-list';
+import {Sort, defaultSort} from './dataset-list';
 
-interface SearchDatasets {
+interface Props {
   licenses: string[];
   publishers: string[];
   query?: string;
@@ -17,15 +17,30 @@ export async function clientSearchDatasets({
   query,
   offset,
   sort,
-}: SearchDatasets): Promise<SearchResult> {
+}: Props): Promise<SearchResult> {
+  const searchParams: {[key: string]: string} = {};
+
   // Convert all values to strings, before using it in URLSearchParams.
-  const searchParams = {
-    query: query || '',
-    licenses: licenses.join(','),
-    publishers: publishers.join(','),
-    offset: `${offset}`,
-    sort,
-  };
+  // And only add to searchParams if needed.
+  if (query) {
+    searchParams.query = query;
+  }
+
+  if (licenses.length) {
+    searchParams.licenses = licenses.join(',');
+  }
+
+  if (publishers.length) {
+    searchParams.publishers = publishers.join(',');
+  }
+
+  if (offset) {
+    searchParams.offset = `${offset}`;
+  }
+
+  if (sort !== defaultSort) {
+    searchParams.sort = sort;
+  }
 
   const response = await fetch(
     '/api/datasets?' + new URLSearchParams(searchParams)

--- a/src/app/[locale]/dataset-card.tsx
+++ b/src/app/[locale]/dataset-card.tsx
@@ -14,7 +14,7 @@ export default function DatasetCard({dataset, locale}: Props) {
     <div
       key={dataset.id}
       className="group relative flex flex-col overflow-hidden rounded-lg border border-gray-200 bg-white"
-      data-test="dataset-card"
+      data-testid="dataset-card"
     >
       <div className="flex flex-1 flex-col space-y-2 p-4">
         <h3 className="text-sm font-medium text-gray-900">

--- a/src/app/[locale]/dataset-list.cy.tsx
+++ b/src/app/[locale]/dataset-list.cy.tsx
@@ -89,12 +89,15 @@ describe('Dataset list filters', () => {
 
   it('filters by one license', () => {
     cy.get<SearchResult>('@searchResult').then(searchResult => {
+      const filterRequestUrl =
+        '/api/datasets?' +
+        new URLSearchParams({
+          licenses: searchResult.filters.licenses[0].id,
+        });
       cy.intercept(
         {
           method: 'GET',
-          url: `/api/datasets?licenses=${encodeURIComponent(
-            searchResult.filters.licenses[0].id
-          )}`,
+          url: filterRequestUrl,
         },
         cy.spy().as('filterRequest')
       );
@@ -114,15 +117,18 @@ describe('Dataset list filters', () => {
 
   it('filters by two licenses', () => {
     cy.get<SearchResult>('@searchResult').then(searchResult => {
+      const filterRequestUrl =
+        '/api/datasets?' +
+        new URLSearchParams({
+          licenses: [
+            searchResult.filters.licenses[0].id,
+            searchResult.filters.licenses[1].id,
+          ].join(),
+        });
       cy.intercept(
         {
           method: 'GET',
-          url: `/api/datasets?licenses=${encodeURIComponent(
-            [
-              searchResult.filters.licenses[0].id,
-              searchResult.filters.licenses[1].id,
-            ].join()
-          )}`,
+          url: filterRequestUrl,
         },
         cy.spy().as('filterRequest')
       );
@@ -185,12 +191,15 @@ describe('Dataset list filters', () => {
 
   it('filters by one publisher', () => {
     cy.get<SearchResult>('@searchResult').then(searchResult => {
+      const filterRequestUrl =
+        '/api/datasets?' +
+        new URLSearchParams({
+          publishers: searchResult.filters.publishers[0].id,
+        });
       cy.intercept(
         {
           method: 'GET',
-          url: `/api/datasets?publishers=${encodeURIComponent(
-            searchResult.filters.publishers[0].id
-          )}`,
+          url: filterRequestUrl,
         },
         cy.spy().as('filterRequest')
       );
@@ -209,31 +218,41 @@ describe('Dataset list filters', () => {
   });
 
   it('filters based on the search query', () => {
+    const searchText = 'My query';
+    const filterRequestUrl =
+      '/api/datasets?' +
+      new URLSearchParams({
+        query: searchText,
+      });
     cy.intercept(
       {
         method: 'GET',
-        url: '/api/datasets?query=My+query',
+        url: filterRequestUrl,
       },
       cy.spy().as('filterRequest')
     );
 
-    cy.getBySel('searchQuery').type('My query');
+    cy.getBySel('searchQuery').type(searchText);
 
     cy.get('@filterRequest').should('have.been.called');
     cy.getBySel('selectedFilterTag').should('have.length', 1);
-    cy.getBySel('selectedFilterTag').should('have.text', 'My query');
+    cy.getBySel('selectedFilterTag').should('have.text', searchText);
   });
 
   it('filters all categories together (query, license and publisher)', () => {
     cy.get<SearchResult>('@searchResult').then(searchResult => {
+      const searchText = 'My query';
+      const filterRequestUrl =
+        '/api/datasets?' +
+        new URLSearchParams({
+          query: searchText,
+          licenses: searchResult.filters.licenses[0].id,
+          publishers: searchResult.filters.publishers[0].id,
+        });
       cy.intercept(
         {
           method: 'GET',
-          url: `/api/datasets?query=My+query&licenses=${encodeURIComponent(
-            searchResult.filters.licenses[0].id
-          )}&publishers=${encodeURIComponent(
-            searchResult.filters.publishers[0].id
-          )}`,
+          url: filterRequestUrl,
         },
         cy.spy().as('filterRequest')
       );

--- a/src/app/[locale]/dataset-list.cy.tsx
+++ b/src/app/[locale]/dataset-list.cy.tsx
@@ -107,8 +107,8 @@ describe('Dataset list filters', () => {
       });
 
       cy.get('@filterRequest').should('have.been.called');
-      cy.getBySel('selectedFilterTag').should('have.length', 1);
-      cy.getBySel('selectedFilterTag').should(
+      cy.getBySel('selectedFilter').should('have.length', 1);
+      cy.getBySel('selectedFilter').should(
         'have.text',
         searchResult.filters.licenses[0].name
       );
@@ -139,11 +139,11 @@ describe('Dataset list filters', () => {
       });
 
       cy.get('@filterRequest').should('have.been.called');
-      cy.getBySel('selectedFilterTag').should('have.length', 2);
-      cy.getBySel('selectedFilterTag')
+      cy.getBySel('selectedFilter').should('have.length', 2);
+      cy.getBySel('selectedFilter')
         .eq(0)
         .should('have.text', searchResult.filters.licenses[0].name);
-      cy.getBySel('selectedFilterTag')
+      cy.getBySel('selectedFilter')
         .eq(1)
         .should('have.text', searchResult.filters.licenses[1].name);
     });
@@ -167,7 +167,7 @@ describe('Dataset list filters', () => {
     });
 
     cy.get('@filterRequest').should('have.been.called');
-    cy.getBySel('selectedFilterTag').should('have.length', 0);
+    cy.getBySel('selectedFilter').should('have.length', 0);
   });
 
   it('removes a license filter by deselecting it in the selected filter bar', () => {
@@ -183,10 +183,12 @@ describe('Dataset list filters', () => {
       cy.spy().as('filterRequest')
     );
 
-    cy.getBySel('removeSelectedFilter').click();
+    cy.getBySel('selectedFilter').within(() => {
+      cy.get('button').click();
+    });
 
     cy.get('@filterRequest').should('have.been.called');
-    cy.getBySel('selectedFilterTag').should('have.length', 0);
+    cy.getBySel('selectedFilter').should('have.length', 0);
   });
 
   it('filters by one publisher', () => {
@@ -209,8 +211,8 @@ describe('Dataset list filters', () => {
       });
 
       cy.get('@filterRequest').should('have.been.called');
-      cy.getBySel('selectedFilterTag').should('have.length', 1);
-      cy.getBySel('selectedFilterTag').should(
+      cy.getBySel('selectedFilter').should('have.length', 1);
+      cy.getBySel('selectedFilter').should(
         'have.text',
         searchResult.filters.publishers[0].name
       );
@@ -235,8 +237,8 @@ describe('Dataset list filters', () => {
     cy.getBySel('searchQuery').type(searchText);
 
     cy.get('@filterRequest').should('have.been.called');
-    cy.getBySel('selectedFilterTag').should('have.length', 1);
-    cy.getBySel('selectedFilterTag').should('have.text', searchText);
+    cy.getBySel('selectedFilter').should('have.length', 1);
+    cy.getBySel('selectedFilter').should('have.text', searchText);
   });
 
   it('filters all categories together (query, license and publisher)', () => {
@@ -266,7 +268,7 @@ describe('Dataset list filters', () => {
       });
 
       cy.get('@filterRequest').should('have.been.called');
-      cy.getBySel('selectedFilterTag').should('have.length', 3);
+      cy.getBySel('selectedFilter').should('have.length', 3);
     });
   });
 });

--- a/src/app/[locale]/dataset-list.cy.tsx
+++ b/src/app/[locale]/dataset-list.cy.tsx
@@ -1,6 +1,7 @@
 import DatasetList, {Props} from './dataset-list';
 import {NextIntlClientProvider} from 'next-intl';
 import messages from '@/messages/en.json';
+import {SearchResult} from '@/lib/dataset-fetcher';
 
 function DatasetListWithTranslation(props: Props) {
   return (
@@ -72,72 +73,77 @@ describe('List rendering', () => {
 });
 
 describe('Dataset list filters', () => {
-  beforeEach(function () {
-    cy.fixture('search-results/three-datasets.json').then(searchResult => {
-      this.searchResult = searchResult;
-      cy.intercept({method: 'GET', url: '/api/datasets?*'}, searchResult);
-      cy.mount(
-        <DatasetListWithTranslation
-          initialSearchResult={searchResult}
-          locale="en"
-        />
+  beforeEach(() => {
+    cy.fixture('search-results/three-datasets.json')
+      .as('searchResult')
+      .then(searchResult => {
+        cy.intercept({method: 'GET', url: '/api/datasets?*'}, searchResult);
+        cy.mount(
+          <DatasetListWithTranslation
+            initialSearchResult={searchResult}
+            locale="en"
+          />
+        );
+      });
+  });
+
+  it('filters by one license', () => {
+    cy.get<SearchResult>('@searchResult').then(searchResult => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `/api/datasets?licenses=${encodeURIComponent(
+            searchResult.filters.licenses[0].id
+          )}`,
+        },
+        cy.spy().as('filterRequest')
+      );
+
+      cy.getBySel('licensesFilter').within(() => {
+        cy.get('[type="checkbox"]').first().check();
+      });
+
+      cy.get('@filterRequest').should('have.been.called');
+      cy.getBySel('selectedFilterTag').should('have.length', 1);
+      cy.getBySel('selectedFilterTag').should(
+        'have.text',
+        searchResult.filters.licenses[0].name
       );
     });
   });
 
-  it('can filter by one license', function () {
-    cy.intercept(
-      {
-        method: 'GET',
-        url: `/api/datasets?licenses=${encodeURIComponent(
-          this.searchResult.filters.licenses[0].id
-        )}`,
-      },
-      cy.spy().as('filterRequest')
-    );
+  it('filters by two licenses', () => {
+    cy.get<SearchResult>('@searchResult').then(searchResult => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `/api/datasets?licenses=${encodeURIComponent(
+            [
+              searchResult.filters.licenses[0].id,
+              searchResult.filters.licenses[1].id,
+            ].join()
+          )}`,
+        },
+        cy.spy().as('filterRequest')
+      );
 
-    cy.getBySel('licensesFilter').within(() => {
-      cy.get('[type="checkbox"]').first().check();
+      cy.getBySel('licensesFilter').within(() => {
+        cy.get('[type="checkbox"]').eq(0).check();
+        cy.get('[type="checkbox"]').eq(1).check();
+      });
+
+      cy.get('@filterRequest').should('have.been.called');
+      cy.getBySel('selectedFilterTag').should('have.length', 2);
+      cy.getBySel('selectedFilterTag')
+        .eq(0)
+        .should('have.text', searchResult.filters.licenses[0].name);
+      cy.getBySel('selectedFilterTag')
+        .eq(1)
+        .should('have.text', searchResult.filters.licenses[1].name);
     });
-
-    cy.get('@filterRequest').should('have.been.called');
-    cy.getBySel('selectedFilterTag').should('have.length', 1);
-    cy.getBySel('selectedFilterTag').should(
-      'have.text',
-      this.searchResult.filters.licenses[0].name
-    );
   });
 
-  it('can filter by two licenses', function () {
-    cy.intercept(
-      {
-        method: 'GET',
-        url: `/api/datasets?licenses=${encodeURIComponent(
-          [
-            this.searchResult.filters.licenses[0].id,
-            this.searchResult.filters.licenses[1].id,
-          ].join()
-        )}`,
-      },
-      cy.spy().as('filterRequest')
-    );
-
-    cy.getBySel('licensesFilter').within(() => {
-      cy.get('[type="checkbox"]').eq(0).check();
-      cy.get('[type="checkbox"]').eq(1).check();
-    });
-
-    cy.get('@filterRequest').should('have.been.called');
-    cy.getBySel('selectedFilterTag').should('have.length', 2);
-    cy.getBySel('selectedFilterTag')
-      .eq(0)
-      .should('have.text', this.searchResult.filters.licenses[0].name);
-    cy.getBySel('selectedFilterTag')
-      .eq(1)
-      .should('have.text', this.searchResult.filters.licenses[1].name);
-  });
-
-  it('can remove a license filter by deselecting the filter in the sidebar', () => {
+  it('removes a license filter by deselecting the filter in the sidebar', () => {
     cy.getBySel('licensesFilter').within(() => {
       cy.get('[type="checkbox"]').first().check();
     });
@@ -158,7 +164,7 @@ describe('Dataset list filters', () => {
     cy.getBySel('selectedFilterTag').should('have.length', 0);
   });
 
-  it('can remove a license filter by deselecting it in the selected filter bar', () => {
+  it('removes a license filter by deselecting it in the selected filter bar', () => {
     cy.getBySel('licensesFilter').within(() => {
       cy.get('[type="checkbox"]').first().check();
     });
@@ -177,30 +183,32 @@ describe('Dataset list filters', () => {
     cy.getBySel('selectedFilterTag').should('have.length', 0);
   });
 
-  it('can filter by one publisher', function () {
-    cy.intercept(
-      {
-        method: 'GET',
-        url: `/api/datasets?publishers=${encodeURIComponent(
-          this.searchResult.filters.publishers[0].id
-        )}`,
-      },
-      cy.spy().as('filterRequest')
-    );
+  it('filters by one publisher', () => {
+    cy.get<SearchResult>('@searchResult').then(searchResult => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `/api/datasets?publishers=${encodeURIComponent(
+            searchResult.filters.publishers[0].id
+          )}`,
+        },
+        cy.spy().as('filterRequest')
+      );
 
-    cy.getBySel('publishersFilter').within(() => {
-      cy.get('[type="checkbox"]').first().check();
+      cy.getBySel('publishersFilter').within(() => {
+        cy.get('[type="checkbox"]').first().check();
+      });
+
+      cy.get('@filterRequest').should('have.been.called');
+      cy.getBySel('selectedFilterTag').should('have.length', 1);
+      cy.getBySel('selectedFilterTag').should(
+        'have.text',
+        searchResult.filters.publishers[0].name
+      );
     });
-
-    cy.get('@filterRequest').should('have.been.called');
-    cy.getBySel('selectedFilterTag').should('have.length', 1);
-    cy.getBySel('selectedFilterTag').should(
-      'have.text',
-      this.searchResult.filters.publishers[0].name
-    );
   });
 
-  it('can filter based on the search query', () => {
+  it('filters based on the search query', () => {
     cy.intercept(
       {
         method: 'GET',
@@ -216,28 +224,30 @@ describe('Dataset list filters', () => {
     cy.getBySel('selectedFilterTag').should('have.text', 'My query');
   });
 
-  it('can filter all categories together (query, license and publisher)', function () {
-    cy.intercept(
-      {
-        method: 'GET',
-        url: `/api/datasets?query=My+query&licenses=${encodeURIComponent(
-          this.searchResult.filters.licenses[0].id
-        )}&publishers=${encodeURIComponent(
-          this.searchResult.filters.publishers[0].id
-        )}`,
-      },
-      cy.spy().as('filterRequest')
-    );
+  it('filters all categories together (query, license and publisher)', () => {
+    cy.get<SearchResult>('@searchResult').then(searchResult => {
+      cy.intercept(
+        {
+          method: 'GET',
+          url: `/api/datasets?query=My+query&licenses=${encodeURIComponent(
+            searchResult.filters.licenses[0].id
+          )}&publishers=${encodeURIComponent(
+            searchResult.filters.publishers[0].id
+          )}`,
+        },
+        cy.spy().as('filterRequest')
+      );
 
-    cy.getBySel('searchQuery').type('My query');
-    cy.getBySel('publishersFilter').within(() => {
-      cy.get('[type="checkbox"]').first().check();
-    });
-    cy.getBySel('licensesFilter').within(() => {
-      cy.get('[type="checkbox"]').first().check();
-    });
+      cy.getBySel('searchQuery').type('My query');
+      cy.getBySel('publishersFilter').within(() => {
+        cy.get('[type="checkbox"]').first().check();
+      });
+      cy.getBySel('licensesFilter').within(() => {
+        cy.get('[type="checkbox"]').first().check();
+      });
 
-    cy.get('@filterRequest').should('have.been.called');
-    cy.getBySel('selectedFilterTag').should('have.length', 3);
+      cy.get('@filterRequest').should('have.been.called');
+      cy.getBySel('selectedFilterTag').should('have.length', 3);
+    });
   });
 });

--- a/src/app/[locale]/dataset-list.cy.tsx
+++ b/src/app/[locale]/dataset-list.cy.tsx
@@ -70,3 +70,174 @@ describe('List rendering', () => {
     });
   });
 });
+
+describe('Dataset list filters', () => {
+  beforeEach(function () {
+    cy.fixture('search-results/three-datasets.json').then(searchResult => {
+      this.searchResult = searchResult;
+      cy.intercept({method: 'GET', url: '/api/datasets?*'}, searchResult);
+      cy.mount(
+        <DatasetListWithTranslation
+          initialSearchResult={searchResult}
+          locale="en"
+        />
+      );
+    });
+  });
+
+  it('can filter by one license', function () {
+    cy.intercept(
+      {
+        method: 'GET',
+        url: `/api/datasets?licenses=${encodeURIComponent(
+          this.searchResult.filters.licenses[0].id
+        )}`,
+      },
+      cy.spy().as('filterRequest')
+    );
+
+    cy.getBySel('licensesFilter').within(() => {
+      cy.get('[type="checkbox"]').first().check();
+    });
+
+    cy.get('@filterRequest').should('have.been.called');
+    cy.getBySel('selectedFilterTag').should('have.length', 1);
+    cy.getBySel('selectedFilterTag').should(
+      'have.text',
+      this.searchResult.filters.licenses[0].name
+    );
+  });
+
+  it('can filter by two licenses', function () {
+    cy.intercept(
+      {
+        method: 'GET',
+        url: `/api/datasets?licenses=${encodeURIComponent(
+          [
+            this.searchResult.filters.licenses[0].id,
+            this.searchResult.filters.licenses[1].id,
+          ].join()
+        )}`,
+      },
+      cy.spy().as('filterRequest')
+    );
+
+    cy.getBySel('licensesFilter').within(() => {
+      cy.get('[type="checkbox"]').eq(0).check();
+      cy.get('[type="checkbox"]').eq(1).check();
+    });
+
+    cy.get('@filterRequest').should('have.been.called');
+    cy.getBySel('selectedFilterTag').should('have.length', 2);
+    cy.getBySel('selectedFilterTag')
+      .eq(0)
+      .should('have.text', this.searchResult.filters.licenses[0].name);
+    cy.getBySel('selectedFilterTag')
+      .eq(1)
+      .should('have.text', this.searchResult.filters.licenses[1].name);
+  });
+
+  it('can remove a license filter by deselecting the filter in the sidebar', () => {
+    cy.getBySel('licensesFilter').within(() => {
+      cy.get('[type="checkbox"]').first().check();
+    });
+
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '/api/datasets?',
+      },
+      cy.spy().as('filterRequest')
+    );
+
+    cy.getBySel('licensesFilter').within(() => {
+      cy.get('[type="checkbox"]').first().uncheck();
+    });
+
+    cy.get('@filterRequest').should('have.been.called');
+    cy.getBySel('selectedFilterTag').should('have.length', 0);
+  });
+
+  it('can remove a license filter by deselecting it in the selected filter bar', () => {
+    cy.getBySel('licensesFilter').within(() => {
+      cy.get('[type="checkbox"]').first().check();
+    });
+
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '/api/datasets?',
+      },
+      cy.spy().as('filterRequest')
+    );
+
+    cy.getBySel('removeSelectedFilter').click();
+
+    cy.get('@filterRequest').should('have.been.called');
+    cy.getBySel('selectedFilterTag').should('have.length', 0);
+  });
+
+  it('can filter by one publisher', function () {
+    cy.intercept(
+      {
+        method: 'GET',
+        url: `/api/datasets?publishers=${encodeURIComponent(
+          this.searchResult.filters.publishers[0].id
+        )}`,
+      },
+      cy.spy().as('filterRequest')
+    );
+
+    cy.getBySel('publishersFilter').within(() => {
+      cy.get('[type="checkbox"]').first().check();
+    });
+
+    cy.get('@filterRequest').should('have.been.called');
+    cy.getBySel('selectedFilterTag').should('have.length', 1);
+    cy.getBySel('selectedFilterTag').should(
+      'have.text',
+      this.searchResult.filters.publishers[0].name
+    );
+  });
+
+  it('can filter based on the search query', () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '/api/datasets?query=My+query',
+      },
+      cy.spy().as('filterRequest')
+    );
+
+    cy.getBySel('searchQuery').type('My query');
+
+    cy.get('@filterRequest').should('have.been.called');
+    cy.getBySel('selectedFilterTag').should('have.length', 1);
+    cy.getBySel('selectedFilterTag').should('have.text', 'My query');
+  });
+
+  it('can filter all categories together (query, license and publisher)', function () {
+    cy.intercept(
+      {
+        method: 'GET',
+        url: `/api/datasets?query=My+query&licenses=${encodeURIComponent(
+          this.searchResult.filters.licenses[0].id
+        )}&publishers=${encodeURIComponent(
+          this.searchResult.filters.publishers[0].id
+        )}`,
+      },
+      cy.spy().as('filterRequest')
+    );
+
+    cy.getBySel('searchQuery').type('My query');
+    cy.getBySel('publishersFilter').within(() => {
+      cy.get('[type="checkbox"]').first().check();
+    });
+    cy.getBySel('licensesFilter').within(() => {
+      cy.get('[type="checkbox"]').first().check();
+    });
+
+    cy.get('@filterRequest').should('have.been.called');
+    cy.getBySel('selectedFilterTag').should('have.length', 3);
+  });
+});

--- a/src/app/[locale]/dataset-list.tsx
+++ b/src/app/[locale]/dataset-list.tsx
@@ -71,7 +71,7 @@ export default function DatasetList({initialSearchResult, locale}: Props) {
       <div
         className="bg-orange-100 border-l-4 border-orange-500 text-orange-700 p-4 lg:col-span-3 xl:col-span-4"
         role="alert"
-        data-test="fetch-error"
+        data-testid="fetch-error"
       >
         <p>{t('fetchError')}</p>
       </div>
@@ -89,7 +89,7 @@ export default function DatasetList({initialSearchResult, locale}: Props) {
             {t('search')}
           </label>
           <input
-            data-test="searchQuery"
+            data-testid="searchQuery"
             value={query}
             onChange={e => setQuery(e.target.value)}
             type="text"
@@ -104,7 +104,7 @@ export default function DatasetList({initialSearchResult, locale}: Props) {
             searchResultFilters={data.filters.licenses}
             selectedFilters={selectedLicenses}
             setSelectedFilters={setSelectedLicenses}
-            data-test="licensesFilter"
+            data-testid="licensesFilter"
           />
         )}
         {!!data?.filters?.licenses?.length && (
@@ -113,7 +113,7 @@ export default function DatasetList({initialSearchResult, locale}: Props) {
             searchResultFilters={data.filters.publishers}
             selectedFilters={selectedPublishers}
             setSelectedFilters={setSelectedPublishers}
-            data-test="publishersFilter"
+            data-testid="publishersFilter"
           />
         )}
       </PageSidebar>
@@ -179,7 +179,7 @@ export default function DatasetList({initialSearchResult, locale}: Props) {
             />
           </>
         ) : (
-          <div data-test="no-results">{t('noResults')}</div>
+          <div data-testid="no-results">{t('noResults')}</div>
         )}
       </PageContent>
     </>

--- a/src/app/[locale]/dataset-list.tsx
+++ b/src/app/[locale]/dataset-list.tsx
@@ -14,6 +14,7 @@ import {
   PageHeader,
 } from '@/components/page';
 import {useTranslations} from 'next-intl';
+import SelectedFilters from './selected-filters';
 
 export enum Sort {
   RelevanceDesc = 'relevanceDesc',
@@ -26,12 +27,14 @@ export interface Props {
   locale: string;
 }
 
+export const defaultSort = Sort.RelevanceDesc;
+
 export default function DatasetList({initialSearchResult, locale}: Props) {
   const [selectedLicenses, setSelectedLicenses] = useState<string[]>([]);
   const [selectedPublishers, setSelectedPublishers] = useState<string[]>([]);
   const [query, setQuery] = useState('');
   const [offset, setOffset] = useState(0);
-  const [sort, setSort] = useState<Sort>(Sort.RelevanceDesc);
+  const [sort, setSort] = useState<Sort>(defaultSort);
   const t = useTranslations('Home');
 
   const {data, error} = useQuery({
@@ -86,6 +89,7 @@ export default function DatasetList({initialSearchResult, locale}: Props) {
             {t('search')}
           </label>
           <input
+            data-test="searchQuery"
             value={query}
             onChange={e => setQuery(e.target.value)}
             type="text"
@@ -97,9 +101,10 @@ export default function DatasetList({initialSearchResult, locale}: Props) {
         {!!data?.filters?.licenses?.length && (
           <FilterSet
             title={t('licensesFilter')}
-            searchResultFilters={data.filters?.licenses}
+            searchResultFilters={data.filters.licenses}
             selectedFilters={selectedLicenses}
             setSelectedFilters={setSelectedLicenses}
+            data-test="licensesFilter"
           />
         )}
         {!!data?.filters?.licenses?.length && (
@@ -108,6 +113,7 @@ export default function DatasetList({initialSearchResult, locale}: Props) {
             searchResultFilters={data.filters.publishers}
             selectedFilters={selectedPublishers}
             setSelectedFilters={setSelectedPublishers}
+            data-test="publishersFilter"
           />
         )}
       </PageSidebar>
@@ -135,6 +141,24 @@ export default function DatasetList({initialSearchResult, locale}: Props) {
               </select>
             </div>
           </div>
+          <SelectedFilters
+            filters={[
+              {
+                searchResultFilters: data?.filters.licenses ?? [],
+                selectedFilters: selectedLicenses,
+                setSelectedFilters: setSelectedLicenses,
+              },
+              {
+                searchResultFilters: data?.filters.publishers ?? [],
+                selectedFilters: selectedPublishers,
+                setSelectedFilters: setSelectedPublishers,
+              },
+            ]}
+            query={{
+              value: query,
+              setQuery,
+            }}
+          />
         </PageHeader>
         {data?.totalCount && data?.totalCount > 0 ? (
           <>

--- a/src/app/[locale]/filter-set.tsx
+++ b/src/app/[locale]/filter-set.tsx
@@ -6,7 +6,7 @@ interface Props {
   searchResultFilters: SearchResultFilter[];
   selectedFilters: string[];
   setSelectedFilters: Dispatch<string[]>;
-  'data-test'?: string;
+  testId?: string;
 }
 
 export default function FilterSet({
@@ -14,7 +14,7 @@ export default function FilterSet({
   searchResultFilters,
   selectedFilters,
   setSelectedFilters,
-  'data-test': dataTest,
+  testId,
 }: Props) {
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -30,7 +30,7 @@ export default function FilterSet({
   );
 
   return (
-    <div className="pt-10" data-test={dataTest}>
+    <div className="pt-10" data-testid={testId}>
       <fieldset>
         <legend className="block text-sm font-medium text-gray-900">
           {title}

--- a/src/app/[locale]/filter-set.tsx
+++ b/src/app/[locale]/filter-set.tsx
@@ -6,6 +6,7 @@ interface Props {
   searchResultFilters: SearchResultFilter[];
   selectedFilters: string[];
   setSelectedFilters: Dispatch<string[]>;
+  'data-test'?: string;
 }
 
 export default function FilterSet({
@@ -13,6 +14,7 @@ export default function FilterSet({
   searchResultFilters,
   selectedFilters,
   setSelectedFilters,
+  'data-test': dataTest,
 }: Props) {
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -28,7 +30,7 @@ export default function FilterSet({
   );
 
   return (
-    <div className="pt-10">
+    <div className="pt-10" data-test={dataTest}>
       <fieldset>
         <legend className="block text-sm font-medium text-gray-900">
           {title}

--- a/src/app/[locale]/selected-filters.tsx
+++ b/src/app/[locale]/selected-filters.tsx
@@ -65,11 +65,11 @@ export default function SelectedFilters({filters, query}: Props) {
                 {
                   searchResultFilters.find(
                     searchResultFilter => searchResultFilter.id === id
-                  )?.name
+                  )!.name
                 }
                 <Badge.Action
                   onClick={() =>
-                    removeSelectedFilter({
+                    clearSelectedFilter({
                       id,
                       selectedFilters: selectedFilters,
                       setSelectedFilters: setSelectedFilters,

--- a/src/app/[locale]/selected-filters.tsx
+++ b/src/app/[locale]/selected-filters.tsx
@@ -15,7 +15,7 @@ interface Props {
   };
 }
 
-interface RemoveListItem {
+interface ClearSelectedFilterProps {
   id: string;
   selectedFilters: string[];
   setSelectedFilters: Dispatch<string[]>;
@@ -32,11 +32,11 @@ export default function SelectedFilters({filters, query}: Props) {
     return null;
   }
 
-  function removeSelectedFilter({
+  function clearSelectedFilter({
     id,
     selectedFilters,
     setSelectedFilters,
-  }: RemoveListItem) {
+  }: ClearSelectedFilterProps) {
     setSelectedFilters(selectedFilters.filter(filterId => id !== filterId));
   }
 
@@ -46,9 +46,7 @@ export default function SelectedFilters({filters, query}: Props) {
 
   function clearAllFilters() {
     clearQuery();
-    filters.forEach(filter => {
-      filter.setSelectedFilters([]);
-    });
+    filters.forEach(filter => filter.setSelectedFilters([]));
   }
 
   return (

--- a/src/app/[locale]/selected-filters.tsx
+++ b/src/app/[locale]/selected-filters.tsx
@@ -47,30 +47,33 @@ interface RemoveListItem {
 export default function SelectedFilters({filters, query}: Props) {
   const t = useTranslations('Home');
 
-  function removeListItem({
-    id,
-    selectedFilters,
-    setSelectedFilters,
-  }: RemoveListItem) {
-    setSelectedFilters(selectedFilters.filter(filterId => id !== filterId));
-  }
-  function removeQuery() {
-    query.setQuery('');
-  }
-
-  function clearAllFilters() {
-    removeQuery();
-    filters.forEach(filter => {
-      filter.setSelectedFilters([]);
-    });
-  }
-
+  // Only show this component if there are active filters.
   if (
     !query.value &&
     !filters.filter(filter => filter.selectedFilters.length).length
   ) {
     return null;
   }
+
+  function removeSelectedFilter({
+    id,
+    selectedFilters,
+    setSelectedFilters,
+  }: RemoveListItem) {
+    setSelectedFilters(selectedFilters.filter(filterId => id !== filterId));
+  }
+
+  function clearQuery() {
+    query.setQuery('');
+  }
+
+  function clearAllFilters() {
+    clearQuery();
+    filters.forEach(filter => {
+      filter.setSelectedFilters([]);
+    });
+  }
+
   return (
     <div className="mt-3 flex items-center">
       <h3 className="text-xs font-medium text-gray-500">{t('filters')}</h3>
@@ -91,7 +94,7 @@ export default function SelectedFilters({filters, query}: Props) {
                   )?.name
                 }
                 remove={() =>
-                  removeListItem({
+                  removeSelectedFilter({
                     id,
                     selectedFilters: selectedFilters,
                     setSelectedFilters: setSelectedFilters,
@@ -100,7 +103,7 @@ export default function SelectedFilters({filters, query}: Props) {
               />
             ))
         )}
-        {query.value && <Tag remove={removeQuery} name={query.value} />}
+        {query.value && <Tag remove={clearQuery} name={query.value} />}
       </div>
       <button
         type="button"

--- a/src/app/[locale]/selected-filters.tsx
+++ b/src/app/[locale]/selected-filters.tsx
@@ -61,7 +61,7 @@ export default function SelectedFilters({filters, query}: Props) {
           ({selectedFilters, searchResultFilters, setSelectedFilters}) =>
             !!selectedFilters.length &&
             selectedFilters.map(id => (
-              <Badge key={id} data-test="selectedFilter">
+              <Badge key={id} data-testid="selectedFilter">
                 {
                   searchResultFilters.find(
                     searchResultFilter => searchResultFilter.id === id
@@ -80,7 +80,7 @@ export default function SelectedFilters({filters, query}: Props) {
             ))
         )}
         {query.value && (
-          <Badge data-test="selectedFilter">
+          <Badge data-testid="selectedFilter">
             {query.value}
             <Badge.Action onClick={clearQuery} />
           </Badge>

--- a/src/app/[locale]/selected-filters.tsx
+++ b/src/app/[locale]/selected-filters.tsx
@@ -1,0 +1,114 @@
+import {SearchResultFilter} from '@/lib/dataset-fetcher';
+import {Dispatch} from 'react';
+import {useTranslations} from 'next-intl';
+import {XMarkIcon} from '@heroicons/react/24/solid';
+
+interface TagProps {
+  name?: string;
+  remove: () => void;
+}
+
+function Tag({name, remove}: TagProps) {
+  return (
+    <span className="flex items-center" data-test="selectedFilterTag">
+      <span className="m-1 inline-flex items-center rounded-full border border-gray-200 bg-white py-1.5 pl-3 pr-2 text-xs font-medium text-gray-900">
+        <span>{name}</span>
+        <button
+          data-test="removeSelectedFilter"
+          type="button"
+          className="ml-1 inline-flex flex-shrink-0 rounded-full p-1 text-gray-400 hover:bg-gray-200 hover:text-gray-500"
+          onClick={remove}
+        >
+          <XMarkIcon className="h-3 w-3" />
+        </button>
+      </span>
+    </span>
+  );
+}
+
+interface Props {
+  filters: {
+    searchResultFilters: SearchResultFilter[];
+    selectedFilters: string[];
+    setSelectedFilters: Dispatch<string[]>;
+  }[];
+  query: {
+    value: string;
+    setQuery: Dispatch<string>;
+  };
+}
+
+interface RemoveListItem {
+  id: string;
+  selectedFilters: string[];
+  setSelectedFilters: Dispatch<string[]>;
+}
+
+export default function SelectedFilters({filters, query}: Props) {
+  const t = useTranslations('Home');
+
+  function removeListItem({
+    id,
+    selectedFilters,
+    setSelectedFilters,
+  }: RemoveListItem) {
+    setSelectedFilters(selectedFilters.filter(filterId => id !== filterId));
+  }
+  function removeQuery() {
+    query.setQuery('');
+  }
+
+  function clearAllFilters() {
+    removeQuery();
+    filters.forEach(filter => {
+      filter.setSelectedFilters([]);
+    });
+  }
+
+  if (
+    !query.value &&
+    !filters.filter(filter => filter.selectedFilters.length).length
+  ) {
+    return null;
+  }
+  return (
+    <div className="mt-3 flex items-center">
+      <h3 className="text-xs font-medium text-gray-500">{t('filters')}</h3>
+      <div
+        aria-hidden="true"
+        className="hidden h-5 w-px bg-gray-300 sm:ml-3 sm:block mr-2"
+      />
+      <div className="flex flex-wrap grow">
+        {filters.map(
+          ({selectedFilters, searchResultFilters, setSelectedFilters}) =>
+            !!selectedFilters.length &&
+            selectedFilters.map(item => (
+              <Tag
+                key={item}
+                name={
+                  searchResultFilters.find(
+                    searchResultFilter => searchResultFilter.id === item
+                  )?.name
+                }
+                remove={() =>
+                  removeListItem({
+                    id: item,
+                    selectedFilters: selectedFilters,
+                    setSelectedFilters: setSelectedFilters,
+                  })
+                }
+              />
+            ))
+        )}
+        {query.value && <Tag remove={removeQuery} name={query.value} />}
+      </div>
+      <button
+        type="button"
+        className="whitespace-nowrap inline-flex items-center rounded border border-transparent bg-indigo-100 px-2.5 py-1.5 text-xs font-medium text-indigo-700 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+        onClick={clearAllFilters}
+      >
+        {t('clearAllFilters')}
+      </button>
+    </div>
+  );
+}

--- a/src/app/[locale]/selected-filters.tsx
+++ b/src/app/[locale]/selected-filters.tsx
@@ -1,30 +1,7 @@
 import {SearchResultFilter} from '@/lib/dataset-fetcher';
 import {Dispatch} from 'react';
 import {useTranslations} from 'next-intl';
-import {XMarkIcon} from '@heroicons/react/24/solid';
-
-interface TagProps {
-  name?: string;
-  remove: () => void;
-}
-
-function Tag({name, remove}: TagProps) {
-  return (
-    <span className="flex items-center" data-test="selectedFilterTag">
-      <span className="m-1 inline-flex items-center rounded-full border border-gray-200 bg-white py-1.5 pl-3 pr-2 text-xs font-medium text-gray-900">
-        <span>{name}</span>
-        <button
-          data-test="removeSelectedFilter"
-          type="button"
-          className="ml-1 inline-flex flex-shrink-0 rounded-full p-1 text-gray-400 hover:bg-gray-200 hover:text-gray-500"
-          onClick={remove}
-        >
-          <XMarkIcon className="h-3 w-3" />
-        </button>
-      </span>
-    </span>
-  );
-}
+import Badge from '@/components/badge';
 
 interface Props {
   filters: {
@@ -86,24 +63,30 @@ export default function SelectedFilters({filters, query}: Props) {
           ({selectedFilters, searchResultFilters, setSelectedFilters}) =>
             !!selectedFilters.length &&
             selectedFilters.map(id => (
-              <Tag
-                key={id}
-                name={
+              <Badge key={id} data-test="selectedFilter">
+                {
                   searchResultFilters.find(
                     searchResultFilter => searchResultFilter.id === id
                   )?.name
                 }
-                remove={() =>
-                  removeSelectedFilter({
-                    id,
-                    selectedFilters: selectedFilters,
-                    setSelectedFilters: setSelectedFilters,
-                  })
-                }
-              />
+                <Badge.Action
+                  onClick={() =>
+                    removeSelectedFilter({
+                      id,
+                      selectedFilters: selectedFilters,
+                      setSelectedFilters: setSelectedFilters,
+                    })
+                  }
+                />
+              </Badge>
             ))
         )}
-        {query.value && <Tag remove={clearQuery} name={query.value} />}
+        {query.value && (
+          <Badge data-test="selectedFilter">
+            {query.value}
+            <Badge.Action onClick={clearQuery} />
+          </Badge>
+        )}
       </div>
       <button
         type="button"

--- a/src/app/[locale]/selected-filters.tsx
+++ b/src/app/[locale]/selected-filters.tsx
@@ -82,17 +82,17 @@ export default function SelectedFilters({filters, query}: Props) {
         {filters.map(
           ({selectedFilters, searchResultFilters, setSelectedFilters}) =>
             !!selectedFilters.length &&
-            selectedFilters.map(item => (
+            selectedFilters.map(id => (
               <Tag
-                key={item}
+                key={id}
                 name={
                   searchResultFilters.find(
-                    searchResultFilter => searchResultFilter.id === item
+                    searchResultFilter => searchResultFilter.id === id
                   )?.name
                 }
                 remove={() =>
                   removeListItem({
-                    id: item,
+                    id,
                     selectedFilters: selectedFilters,
                     setSelectedFilters: setSelectedFilters,
                   })

--- a/src/components/badge.tsx
+++ b/src/components/badge.tsx
@@ -3,13 +3,13 @@ import {XMarkIcon} from '@heroicons/react/24/solid';
 
 interface Props {
   children: ReactNode;
-  'data-test'?: string;
+  testId?: string;
 }
 
-export default function Badge({children, 'data-test': dataTest}: Props) {
+export default function Badge({children, testId}: Props) {
   return (
     <span
-      data-test={dataTest}
+      data-testid={testId}
       className="m-1 inline-flex items-center rounded-full border border-gray-200 bg-white py-1.5 pl-3 pr-2 text-xs font-medium text-gray-900"
     >
       {children}

--- a/src/components/badge.tsx
+++ b/src/components/badge.tsx
@@ -17,12 +17,12 @@ export default function Badge({children, 'data-test': dataTest}: Props) {
   );
 }
 
-interface TagActionProps {
+interface BadgeActionProps {
   Icon?: React.ElementType;
   onClick: () => void;
 }
 
-function BadgeAction({Icon = XMarkIcon, onClick}: TagActionProps) {
+function BadgeAction({Icon = XMarkIcon, onClick}: BadgeActionProps) {
   return (
     <button
       type="button"

--- a/src/components/badge.tsx
+++ b/src/components/badge.tsx
@@ -1,0 +1,37 @@
+import {ReactNode} from 'react';
+import {XMarkIcon} from '@heroicons/react/24/solid';
+
+interface Props {
+  children: ReactNode;
+  'data-test'?: string;
+}
+
+export default function Badge({children, 'data-test': dataTest}: Props) {
+  return (
+    <span
+      data-test={dataTest}
+      className="m-1 inline-flex items-center rounded-full border border-gray-200 bg-white py-1.5 pl-3 pr-2 text-xs font-medium text-gray-900"
+    >
+      {children}
+    </span>
+  );
+}
+
+interface TagActionProps {
+  Icon?: React.ElementType;
+  onClick: () => void;
+}
+
+function BadgeAction({Icon = XMarkIcon, onClick}: TagActionProps) {
+  return (
+    <button
+      type="button"
+      className="ml-1 inline-flex flex-shrink-0 rounded-full p-1 text-gray-400 hover:bg-gray-200 hover:text-gray-500"
+      onClick={onClick}
+    >
+      <Icon className="h-3 w-3" />
+    </button>
+  );
+}
+
+Badge.Action = BadgeAction;

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -11,7 +11,9 @@
     "sortRelevanceDesc": "Relevance",
     "sortNameAsc": "Name - Ascending",
     "sortNameDesc": "Name - Descending",
-    "fetchError": "There was a problem fetching the datasets. Please reload the page to try again."
+    "fetchError": "There was a problem fetching the datasets. Please reload the page to try again.",
+    "filters": "filters",
+    "clearAllFilters": "Clear all"
   },
   "Paginator": {
     "results": "Showing <number>{start}</number> to <number>{end}</number> of <number>{totalCount}</number> results",

--- a/src/messages/nl.json
+++ b/src/messages/nl.json
@@ -11,7 +11,9 @@
     "sortRelevanceDesc": "Relevantie",
     "sortNameAsc": "Naam - Oplopend",
     "sortNameDesc": "Naam - Aflopend",
-    "fetchError": "Er is een probleem opgetreden bij het ophalen van de datasets. Laad de pagina opnieuw om het opnieuw te proberen."
+    "fetchError": "Er is een probleem opgetreden bij het ophalen van de datasets. Laad de pagina opnieuw om het opnieuw te proberen.",
+    "filters": "filters",
+    "clearAllFilters": "Alles verwijderen"
   },
   "Paginator": {
     "results": "Resultaat <number>{start}</number> tot <number>{end}</number> van de <number>{totalCount}</number>",


### PR DESCRIPTION
This will add selected filters to the top of the page.

I updated [src/app/[locale]/client-search-dataset.ts](https://github.com/colonial-heritage/dataset-browser/pull/84/files#diff-2fe5552b9d682949e687bf4240ad02fab334dbd46ea4142503866ffd5213fbd1), so it will only add the needed search params to the API call. This is so the tests are a bit cleaner. Eventually, I want to use the same logic to add the search params to the URL for shareability. So this was also preparation for that logic.