### PR TITLE
fix: set engines to fixed Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "files": [],
   "engines": {
-    "node": ">=18.0.0"
+    "node": "18.x"
   },
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
Tiny fix. Vercel generates warnings due to the version range specifier (`>=`). The range suggests that the Dataset Browser could also run on future Node versions (19, 20, ...), but we don't know whether that is the case - a future version could be backward incompatible.