### PR TITLE
Run cypress e2e tests after succesful deployment

### DIFF
--- a/.github/workflows/end-to-end-testing.yml
+++ b/.github/workflows/end-to-end-testing.yml
@@ -6,11 +6,6 @@ jobs:
     if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: |
-          echo "$GITHUB_CONTEXT"
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run Cypress 🌲


### PR DESCRIPTION
There are multiple tests failing on the `main` branch. To prevent this from happening in the future, I have added a ci job for the e2e tests.

The tests are fixed in #108 

In the pull request mentioned above, I have removed the component tests, because they don't work well with server components. If we decide to add component tests, this job probably needs to be updated.