### PR TITLE
Container layout

### DIFF
--- a/src/app/[locale]/client-filters.tsx
+++ b/src/app/[locale]/client-filters.tsx
@@ -11,12 +11,7 @@ import {
 import {SearchResult} from '@/lib/dataset-fetcher';
 import FilterSet from './filter-set';
 import Paginator from './paginator';
-import {
-  PageSidebar,
-  PageContent,
-  PageTitle,
-  PageHeader,
-} from '@/components/page';
+import {PageTitle, PageHeader} from '@/components/page';
 import {useTranslations} from 'next-intl';
 import SelectedFilters from './selected-filters';
 import {useRouter} from 'next/navigation';
@@ -184,9 +179,11 @@ export default function ClientFilters({
           </div>
         </Dialog>
       </Transition.Root>
-      <PageSidebar>{renderFilters}</PageSidebar>
+      <aside className="self-stretch hidden md:flex md:h-full w-full md:w-1/3 flex-row md:flex-col gap-10 overscroll-x-auto flex-nowrap border-white border-r-2">
+        {renderFilters}
+      </aside>
 
-      <PageContent>
+      <section className="w-full md:w-2/3 gap-6 flex flex-col">
         <button
           type="button"
           className="inline-flex items-center md:hidden"
@@ -250,7 +247,7 @@ export default function ClientFilters({
             limit={limit}
           />
         ) : null}
-      </PageContent>
+      </section>
     </>
   );
 }

--- a/src/app/[locale]/dataset/[id]/page.tsx
+++ b/src/app/[locale]/dataset/[id]/page.tsx
@@ -1,10 +1,5 @@
 import {getTranslations} from 'next-intl/server';
 import {PageHeader, PageTitle} from '@/components/page';
-import {
-  PageWithSidebarContainer,
-  PageSidebar,
-  PageContent,
-} from '@/components/page';
 import {ChevronLeftIcon} from '@heroicons/react/24/solid';
 import datasetFetcher from '@/lib/dataset-fetcher-instance';
 import {Link} from 'next-intl';
@@ -78,8 +73,8 @@ export default async function Details({params}: Props) {
   ];
 
   return (
-    <PageWithSidebarContainer>
-      <PageSidebar>
+    <div className="flex flex-col md:flex-row justify-between gap-6">
+      <aside className="md:h-full w-full sm:w-1/5 flex flex-row md:flex-col border-r-2 border-white">
         <div>
           <Link
             href="/"
@@ -100,10 +95,10 @@ export default async function Details({params}: Props) {
             ))}
           </nav>
         </div>
-      </PageSidebar>
-      <PageContent>
+      </aside>
+      <section className="w-full sm:w-4/5 gap-6 flex flex-col">
         <div className="divide-y-4 divide-white flex flex-col">
-          <div className="py-10">
+          <div className="pb-10">
             <PageHeader>
               <PageTitle id="about">{dataset.name}</PageTitle>
             </PageHeader>
@@ -123,7 +118,7 @@ export default async function Details({params}: Props) {
             ))}
           </div>
         </div>
-      </PageContent>
-    </PageWithSidebarContainer>
+      </section>
+    </div>
   );
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -59,7 +59,9 @@ export default function RootLayout({children, params}: Props) {
             locale={locale}
           />
         </header>
-        <main className="bg-gray-light">{children}</main>
+        <main className="bg-gray-light">
+          <div className="max-w-7xl container mx-auto p-8">{children}</div>
+        </main>
       </body>
     </html>
   );

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,4 +1,3 @@
-import {PageWithSidebarContainer} from '@/components/page';
 import datasetFetcher from '@/lib/dataset-fetcher-instance';
 import {useLocale, NextIntlClientProvider} from 'next-intl';
 import {getTranslations} from 'next-intl/server';
@@ -99,7 +98,7 @@ export default async function Home({searchParams}: Props) {
   const t = await getTranslations('Home');
 
   return (
-    <PageWithSidebarContainer>
+    <div className="flex flex-col md:flex-row justify-between gap-6">
       <NextIntlClientProvider
         locale={locale}
         messages={{
@@ -128,6 +127,6 @@ export default async function Home({searchParams}: Props) {
           </ClientFilters>
         )}
       </NextIntlClientProvider>
-    </PageWithSidebarContainer>
+    </div>
   );
 }

--- a/src/components/page.tsx
+++ b/src/components/page.tsx
@@ -20,27 +20,3 @@ export function PageTitle({children, id}: PageTitleProps) {
     </h1>
   );
 }
-
-export function PageContent({children}: {children: ReactNode}) {
-  return (
-    <section className="w-full md:w-2/3 gap-6 flex flex-col py-8">
-      {children}
-    </section>
-  );
-}
-
-export function PageWithSidebarContainer({children}: {children: ReactNode}) {
-  return (
-    <div className="max-w-7xl container mx-auto flex flex-col md:flex-row justify-between gap-6 px-8">
-      {children}
-    </div>
-  );
-}
-
-export function PageSidebar({children}: {children: ReactNode}) {
-  return (
-    <aside className="self-stretch hidden md:flex md:h-full w-full md:w-1/3 flex-row md:flex-col gap-10 overscroll-x-auto flex-nowrap border-white border-r-2 py-8">
-      {children}
-    </aside>
-  );
-}


### PR DESCRIPTION
There are two problems with the page containers:

  1. Now, pages without sidebars (for example, https://app.colonialcollections.nl/about) have a whole page width. This should be smaller with some more padding.
  2. The details page should have a smaller sidebar than the home page.

I have removed the components `PageWithSidebarContainer`, `PageSidebar` and `PageContent` from '@/components/page'. Because the two pages with sidebars are different, using the same components doesn't make sense.