### PR TITLE
Fix bug: don't remove search params after page load

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,9 @@ const customJestConfig = {
   testMatch: ['**/*.test.ts(x)?'],
   collectCoverage: true,
   setupFiles: ['<rootDir>/jest.setup.js'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
 };
 
 module.exports = createJestConfig(customJestConfig);

--- a/src/app/[locale]/client-filters.tsx
+++ b/src/app/[locale]/client-filters.tsx
@@ -8,23 +8,29 @@ import {
   Fragment,
   useMemo,
 } from 'react';
-import {SearchResult} from '@/lib/dataset-fetcher';
+import {SearchOptions, SearchResult} from '@/lib/dataset-fetcher';
 import FilterSet from './filter-set';
 import Paginator from './paginator';
 import {PageTitle, PageHeader} from '@/components/page';
 import {useTranslations} from 'next-intl';
 import SelectedFilters from './selected-filters';
 import {useRouter} from 'next/navigation';
-import {Sort, defaultSort} from './dataset-list';
 import {Dialog, Transition} from '@headlessui/react';
 import {XMarkIcon} from '@heroicons/react/24/outline';
 import {AdjustmentsHorizontalIcon} from '@heroicons/react/20/solid';
+import {
+  getUrlWithSearchParams,
+  SortBy,
+  defaultSortBy,
+} from '@/lib/search-params';
 
 export interface Props {
   filters: SearchResult['filters'];
   limit: SearchResult['limit'];
   totalCount: SearchResult['totalCount'];
   children: ReactNode;
+  sortBy: SortBy;
+  searchOptions: SearchOptions;
 }
 
 export default function ClientFilters({
@@ -32,12 +38,18 @@ export default function ClientFilters({
   filters,
   limit,
   totalCount,
+  sortBy: initialSortBy,
+  searchOptions,
 }: Props) {
-  const [selectedLicenses, setSelectedLicenses] = useState<string[]>([]);
-  const [selectedPublishers, setSelectedPublishers] = useState<string[]>([]);
-  const [query, setQuery] = useState('');
-  const [offset, setOffset] = useState(0);
-  const [sort, setSort] = useState<Sort>(defaultSort);
+  const [selectedLicenses, setSelectedLicenses] = useState<string[]>(
+    searchOptions?.filters?.licenses ?? []
+  );
+  const [selectedPublishers, setSelectedPublishers] = useState<string[]>(
+    searchOptions?.filters?.publishers ?? []
+  );
+  const [query, setQuery] = useState(searchOptions?.query ?? '');
+  const [offset, setOffset] = useState(searchOptions?.offset ?? 0);
+  const [sortBy, setSortBy] = useState<SortBy>(initialSortBy ?? defaultSortBy);
   const [showFiltersSidebarOnSmallScreen, setShowFiltersSidebarOnSmallScreen] =
     useState(false);
   const t = useTranslations('Home');
@@ -46,39 +58,22 @@ export default function ClientFilters({
   const [, startTransition] = useTransition();
 
   useEffect(() => {
-    const searchParams: {[key: string]: string} = {};
-
-    if (query) {
-      searchParams.query = query;
-    }
-
-    if (selectedLicenses.length) {
-      searchParams.licenses = selectedLicenses.join(',');
-    }
-
-    if (selectedPublishers.length) {
-      searchParams.publishers = selectedPublishers.join(',');
-    }
-
-    if (offset) {
-      searchParams.offset = `${offset}`;
-    }
-
-    if (sort !== defaultSort) {
-      searchParams.sort = sort;
-    }
-    const encodedSearchParams = new URLSearchParams(searchParams).toString();
-    startTransition(() => {
-      if (encodedSearchParams) {
-        router.replace('/?' + encodedSearchParams);
-      } else {
-        router.replace('/' + encodedSearchParams);
-      }
+    const urlWithSearchParams = getUrlWithSearchParams({
+      query,
+      filters: {
+        licenses: selectedLicenses,
+        publishers: selectedPublishers,
+      },
+      offset,
+      sortBy,
     });
-  }, [query, offset, sort, selectedLicenses, selectedPublishers, router]);
+    startTransition(() => {
+      router.replace(urlWithSearchParams);
+    });
+  }, [query, offset, sortBy, selectedLicenses, selectedPublishers, router]);
 
-  function handleSortChange(e: React.ChangeEvent<HTMLSelectElement>) {
-    setSort(e.target.value as Sort);
+  function handleSortByChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    setSortBy(e.target.value as SortBy);
   }
 
   const renderFilters = useMemo(
@@ -206,15 +201,15 @@ export default function ClientFilters({
               <select
                 name="location"
                 className="mt-1 block w-full rounded-md border-gray-300 py-2 pl-3 pr-10 text-base focus:border-sky-500 focus:outline-none focus:ring-sky-500 sm:text-sm"
-                value={sort}
-                onChange={handleSortChange}
+                value={sortBy}
+                onChange={handleSortByChange}
                 aria-label={t('accessibilitySelectToChangeOrder')}
               >
-                <option value={Sort.RelevanceDesc}>
+                <option value={SortBy.RelevanceDesc}>
                   {t('sortRelevanceDesc')}
                 </option>
-                <option value={Sort.NameAsc}>{t('sortNameAsc')}</option>
-                <option value={Sort.NameDesc}>{t('sortNameDesc')}</option>
+                <option value={SortBy.NameAsc}>{t('sortNameAsc')}</option>
+                <option value={SortBy.NameDesc}>{t('sortNameDesc')}</option>
               </select>
             </div>
           </div>

--- a/src/app/[locale]/client-filters.tsx
+++ b/src/app/[locale]/client-filters.tsx
@@ -18,11 +18,7 @@ import {useRouter} from 'next/navigation';
 import {Dialog, Transition} from '@headlessui/react';
 import {XMarkIcon} from '@heroicons/react/24/outline';
 import {AdjustmentsHorizontalIcon} from '@heroicons/react/20/solid';
-import {
-  getUrlWithSearchParams,
-  SortBy,
-  defaultSortBy,
-} from '@/lib/search-params';
+import {getUrlWithSearchParams, SortBy} from '@/lib/search-params';
 
 export interface Props {
   filters: SearchResult['filters'];
@@ -49,7 +45,7 @@ export default function ClientFilters({
   );
   const [query, setQuery] = useState(searchOptions?.query ?? '');
   const [offset, setOffset] = useState(searchOptions?.offset ?? 0);
-  const [sortBy, setSortBy] = useState<SortBy>(initialSortBy ?? defaultSortBy);
+  const [sortBy, setSortBy] = useState<SortBy>(initialSortBy);
   const [showFiltersSidebarOnSmallScreen, setShowFiltersSidebarOnSmallScreen] =
     useState(false);
   const t = useTranslations('Home');

--- a/src/app/[locale]/dataset-list.tsx
+++ b/src/app/[locale]/dataset-list.tsx
@@ -2,14 +2,6 @@ import DatasetCard from './dataset-card';
 import {useTranslations} from 'next-intl';
 import {SearchResult} from '@/lib/dataset-fetcher';
 
-export enum Sort {
-  RelevanceDesc = 'relevanceDesc',
-  NameAsc = 'nameAsc',
-  NameDesc = 'nameDesc',
-}
-
-export const defaultSort = Sort.RelevanceDesc;
-
 interface Props {
   datasets: SearchResult['datasets'];
   totalCount: SearchResult['totalCount'];

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -2,97 +2,23 @@ import datasetFetcher from '@/lib/dataset-fetcher-instance';
 import {useLocale, NextIntlClientProvider} from 'next-intl';
 import {getTranslations} from 'next-intl/server';
 import ClientFilters from './client-filters';
-import DatasetList, {Sort, defaultSort} from './dataset-list';
-import {
-  SearchOptions,
-  SearchResult,
-  SortBy,
-  SortOrder,
-} from '@/lib/dataset-fetcher';
-
-const sortMapping = {
-  [Sort.RelevanceDesc]: {
-    sortBy: SortBy.Relevance,
-    sortOrder: SortOrder.Descending,
-  },
-  [Sort.NameAsc]: {
-    sortBy: SortBy.Name,
-    sortOrder: SortOrder.Ascending,
-  },
-  [Sort.NameDesc]: {
-    sortBy: SortBy.Name,
-    sortOrder: SortOrder.Descending,
-  },
-};
+import DatasetList from './dataset-list';
+import {fromSearchParamsToSearchOptions} from '@/lib/search-params';
 
 interface Props {
-  searchParams?: {
-    publishers?: string;
-    licenses?: string;
-    query?: string;
-    offset?: string;
-    sort?: Sort;
-  };
+  searchParams?: object;
 }
-
-interface ErrorResponse {
-  hasError: true;
-  errorMessage: string;
-  searchResult: null;
-}
-interface SearchResultResponse {
-  hasError: false;
-  searchResult: SearchResult;
-}
-type Response = ErrorResponse | SearchResultResponse;
-
-async function getData({searchParams = {}}: Props): Promise<Response> {
-  const {
-    publishers,
-    licenses,
-    query,
-    offset = '0',
-    sort = defaultSort,
-  } = searchParams;
-
-  const {sortBy, sortOrder} = sortMapping[sort] || {};
-
-  // Transform the string values from the query string to SearchOptions
-  const options = {
-    offset: +offset,
-    filters: {
-      publishers: publishers?.split(',').filter(id => !!id),
-      licenses: licenses?.split(',').filter(id => !!id),
-    },
-    sortBy: sortBy,
-    sortOrder: sortOrder,
-  };
-
-  if (!options.sortBy || !options.sortOrder || isNaN(options.offset)) {
-    return {
-      hasError: true,
-      errorMessage: 'Invalid options',
-      searchResult: null,
-    };
-  }
-
-  const validOptions: SearchOptions = options;
-
-  // Only add a search query if provided
-  if (query) {
-    validOptions.query = query;
-  }
-
-  try {
-    const searchResult = await datasetFetcher.search(validOptions);
-    return {searchResult, hasError: false};
-  } catch (error) {
-    return {hasError: true, errorMessage: 'Fetch error', searchResult: null};
-  }
-}
-
 export default async function Home({searchParams}: Props) {
-  const {searchResult, hasError} = await getData({searchParams});
+  const {searchOptions, sortBy} = fromSearchParamsToSearchOptions(
+    searchParams ?? {}
+  );
+
+  let hasError, searchResult;
+  try {
+    searchResult = await datasetFetcher.search(searchOptions);
+  } catch {
+    hasError = true;
+  }
   const locale = useLocale();
   const messages = (await import(`@/messages/${locale}/messages.json`)).default;
   const t = await getTranslations('Home');
@@ -106,7 +32,7 @@ export default async function Home({searchParams}: Props) {
           Paginator: messages.Paginator,
         }}
       >
-        {hasError ? (
+        {hasError && (
           <div
             className="bg-orange-100 border-l-4 border-orange-500 text-orange-700 p-4 lg:col-span-3 xl:col-span-4"
             role="alert"
@@ -114,8 +40,12 @@ export default async function Home({searchParams}: Props) {
           >
             <p>{t('fetchError')}</p>
           </div>
-        ) : (
+        )}
+
+        {searchResult && (
           <ClientFilters
+            searchOptions={searchOptions}
+            sortBy={sortBy}
             filters={searchResult.filters}
             limit={searchResult.limit}
             totalCount={searchResult.totalCount}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -3,21 +3,28 @@ import {useLocale, NextIntlClientProvider} from 'next-intl';
 import {getTranslations} from 'next-intl/server';
 import ClientFilters from './client-filters';
 import DatasetList from './dataset-list';
-import {fromSearchParamsToSearchOptions} from '@/lib/search-params';
+import {
+  fromSearchParamsToSearchOptions,
+  getClientSortBy,
+  SearchParams,
+} from '@/lib/search-params';
 
 interface Props {
-  searchParams?: object;
+  searchParams?: SearchParams;
 }
 export default async function Home({searchParams}: Props) {
-  const {searchOptions, sortBy} = fromSearchParamsToSearchOptions(
-    searchParams ?? {}
-  );
+  const searchOptions = fromSearchParamsToSearchOptions(searchParams ?? {});
+  const sortBy = getClientSortBy({
+    sortBy: searchOptions.sortBy,
+    sortOrder: searchOptions.sortOrder,
+  });
 
   let hasError, searchResult;
   try {
     searchResult = await datasetFetcher.search(searchOptions);
-  } catch {
+  } catch (error) {
     hasError = true;
+    console.error(error);
   }
   const locale = useLocale();
   const messages = (await import(`@/messages/${locale}/messages.json`)).default;

--- a/src/lib/dataset-fetcher/index.ts
+++ b/src/lib/dataset-fetcher/index.ts
@@ -68,7 +68,7 @@ export enum SortOrder {
 const SortOrderEnum = z.nativeEnum(SortOrder);
 
 // TBD: add language option, for returning results in a specific locale (e.g. 'nl', 'en')
-const searchOptionsSchema = z.object({
+export const searchOptionsSchema = z.object({
   query: z.string().optional().default('*'), // If no query provided, match all
   offset: z.number().int().nonnegative().optional().default(0),
   limit: z.number().int().positive().optional().default(10),

--- a/src/lib/search-params.test.ts
+++ b/src/lib/search-params.test.ts
@@ -2,8 +2,10 @@ import {
   getUrlWithSearchParams,
   fromSearchParamsToSearchOptions,
   defaultSortBy,
+  getClientSortBy,
   SortBy,
 } from './search-params';
+import {SortBy as SortBySearchOption, SortOrder} from '@/lib/dataset-fetcher';
 import {describe, expect, it} from '@jest/globals';
 
 describe('getUrlWithSearchParams', () => {
@@ -94,16 +96,13 @@ describe('getUrlWithSearchParams', () => {
 describe('fromSearchParamsToSearchOptions', () => {
   it('returns default search options if there are no search params', () => {
     expect(fromSearchParamsToSearchOptions({})).toStrictEqual({
-      searchOptions: {
-        filters: {
-          licenses: undefined,
-          publishers: undefined,
-        },
-        offset: 0,
-        sortBy: 'relevance',
-        sortOrder: 'desc',
+      filters: {
+        licenses: undefined,
+        publishers: undefined,
       },
-      sortBy: 'relevanceDesc',
+      offset: 0,
+      sortBy: 'relevance',
+      sortOrder: 'desc',
     });
   });
 
@@ -113,16 +112,13 @@ describe('fromSearchParamsToSearchOptions', () => {
       sortBy: defaultSortBy,
     };
     expect(fromSearchParamsToSearchOptions(searchParams)).toStrictEqual({
-      searchOptions: {
-        filters: {
-          licenses: undefined,
-          publishers: undefined,
-        },
-        offset: 0,
-        sortBy: 'relevance',
-        sortOrder: 'desc',
+      filters: {
+        licenses: undefined,
+        publishers: undefined,
       },
-      sortBy: 'relevanceDesc',
+      offset: 0,
+      sortBy: 'relevance',
+      sortOrder: 'desc',
     });
   });
 
@@ -134,16 +130,13 @@ describe('fromSearchParamsToSearchOptions', () => {
     };
     // @ts-expect-error:TS2553
     expect(fromSearchParamsToSearchOptions(searchParams)).toStrictEqual({
-      searchOptions: {
-        filters: {
-          licenses: undefined,
-          publishers: undefined,
-        },
-        offset: 0,
-        sortBy: 'relevance',
-        sortOrder: 'desc',
+      filters: {
+        licenses: undefined,
+        publishers: undefined,
       },
-      sortBy: 'relevanceDesc',
+      offset: 0,
+      sortBy: 'relevance',
+      sortOrder: 'desc',
     });
   });
 
@@ -156,17 +149,35 @@ describe('fromSearchParamsToSearchOptions', () => {
       publishers: 'publisher',
     };
     expect(fromSearchParamsToSearchOptions(searchParams)).toStrictEqual({
-      searchOptions: {
-        query: 'My query',
-        filters: {
-          licenses: ['license1', 'license2'],
-          publishers: ['publisher'],
-        },
-        offset: 10,
-        sortBy: 'name',
-        sortOrder: 'asc',
+      query: 'My query',
+      filters: {
+        licenses: ['license1', 'license2'],
+        publishers: ['publisher'],
       },
-      sortBy: 'nameAsc',
+      offset: 10,
+      sortBy: 'name',
+      sortOrder: 'asc',
     });
+  });
+});
+
+describe('getClientSortBy', () => {
+  it('finds the client SortBy', () => {
+    expect(
+      getClientSortBy({
+        sortBy: SortBySearchOption.Relevance,
+        sortOrder: SortOrder.Descending,
+      })
+    ).toBe(SortBy.RelevanceDesc);
+  });
+
+  it('throws an error with an invalid sortPair', () => {
+    expect(() =>
+      getClientSortBy({
+        // @ts-expect-error:TS2553
+        sortBy: 'invalid',
+        sortOrder: SortOrder.Descending,
+      })
+    ).toThrow();
   });
 });

--- a/src/lib/search-params.test.ts
+++ b/src/lib/search-params.test.ts
@@ -97,12 +97,14 @@ describe('fromSearchParamsToSearchOptions', () => {
   it('returns default search options if there are no search params', () => {
     expect(fromSearchParamsToSearchOptions({})).toStrictEqual({
       filters: {
-        licenses: undefined,
-        publishers: undefined,
+        licenses: [],
+        publishers: [],
       },
       offset: 0,
       sortBy: 'relevance',
       sortOrder: 'desc',
+      limit: 10,
+      query: undefined,
     });
   });
 
@@ -113,12 +115,14 @@ describe('fromSearchParamsToSearchOptions', () => {
     };
     expect(fromSearchParamsToSearchOptions(searchParams)).toStrictEqual({
       filters: {
-        licenses: undefined,
-        publishers: undefined,
+        licenses: [],
+        publishers: [],
       },
       offset: 0,
       sortBy: 'relevance',
       sortOrder: 'desc',
+      limit: 10,
+      query: undefined,
     });
   });
 
@@ -131,12 +135,14 @@ describe('fromSearchParamsToSearchOptions', () => {
     // @ts-expect-error:TS2553
     expect(fromSearchParamsToSearchOptions(searchParams)).toStrictEqual({
       filters: {
-        licenses: undefined,
-        publishers: undefined,
+        licenses: [],
+        publishers: [],
       },
       offset: 0,
       sortBy: 'relevance',
       sortOrder: 'desc',
+      limit: 10,
+      query: undefined,
     });
   });
 
@@ -157,6 +163,7 @@ describe('fromSearchParamsToSearchOptions', () => {
       offset: 10,
       sortBy: 'name',
       sortOrder: 'asc',
+      limit: 10,
     });
   });
 });

--- a/src/lib/search-params.test.ts
+++ b/src/lib/search-params.test.ts
@@ -178,13 +178,13 @@ describe('getClientSortBy', () => {
     ).toBe(SortBy.RelevanceDesc);
   });
 
-  it('throws an error with an invalid sortPair', () => {
+  it('throws an error with an invalid sort pair', () => {
     expect(() =>
       getClientSortBy({
         // @ts-expect-error:TS2553
         sortBy: 'invalid',
         sortOrder: SortOrder.Descending,
       })
-    ).toThrow();
+    ).toThrow("Cannot read properties of undefined (reading '0')");
   });
 });

--- a/src/lib/search-params.ts
+++ b/src/lib/search-params.ts
@@ -1,0 +1,137 @@
+import {
+  SearchOptions,
+  SortBy as SortBySearchOption,
+  SortOrder,
+} from '@/lib/dataset-fetcher';
+
+export enum SortBy {
+  RelevanceDesc = 'relevanceDesc',
+  NameAsc = 'nameAsc',
+  NameDesc = 'nameDesc',
+}
+
+export const defaultSortBy = SortBy.RelevanceDesc;
+
+const sortMapping = {
+  [SortBy.RelevanceDesc]: {
+    sortBy: SortBySearchOption.Relevance,
+    sortOrder: SortOrder.Descending,
+  },
+  [SortBy.NameAsc]: {
+    sortBy: SortBySearchOption.Name,
+    sortOrder: SortOrder.Ascending,
+  },
+  [SortBy.NameDesc]: {
+    sortBy: SortBySearchOption.Name,
+    sortOrder: SortOrder.Descending,
+  },
+};
+
+interface ToSearchParamsProps {
+  query?: SearchOptions['query'];
+  offset?: SearchOptions['offset'];
+  filters: {
+    licenses?: string[];
+    publishers?: string[];
+  };
+  sortBy?: SortBy;
+}
+
+export function getUrlWithSearchParams({
+  query,
+  offset,
+  filters: {licenses, publishers},
+  sortBy,
+}: ToSearchParamsProps) {
+  const searchParams: {[key: string]: string} = {};
+
+  if (query) {
+    searchParams.query = query;
+  }
+
+  if (licenses?.length) {
+    searchParams.licenses = licenses.join(',');
+  }
+
+  if (publishers?.length) {
+    searchParams.publishers = publishers.join(',');
+  }
+
+  if (offset) {
+    searchParams.offset = `${offset}`;
+  }
+
+  if (sortBy && sortBy !== defaultSortBy) {
+    searchParams.sortBy = sortBy;
+  }
+
+  const encodedSearchParams = new URLSearchParams(searchParams).toString();
+
+  if (encodedSearchParams) {
+    return '/?' + encodedSearchParams;
+  } else {
+    return '/' + encodedSearchParams;
+  }
+}
+
+interface FromSearchParamsToSearchOptionsProps {
+  publishers?: string;
+  licenses?: string;
+  query?: string;
+  offset?: string;
+  sortBy?: SortBy;
+}
+
+interface Response {
+  searchOptions: SearchOptions;
+  sortBy: SortBy;
+}
+
+// This function translates the search params to valid search options.
+// Next.js already separate the search query string into separate properties with string values.
+// Always return a valid SearchOptions object, even if the search params aren't correct,
+// so the application doesn't fail on invalid search params.
+export function fromSearchParamsToSearchOptions({
+  publishers,
+  licenses,
+  query,
+  offset = '0',
+  sortBy = defaultSortBy,
+}: FromSearchParamsToSearchOptionsProps): Response {
+  let sortByResponse = sortBy;
+  const {sortBy: sortBySearchOption, sortOrder} = sortMapping[sortBy] || {};
+
+  // Transform the string values from the search params to SearchOptions
+  const options = {
+    offset: +offset,
+    filters: {
+      publishers: publishers?.split(',').filter(id => !!id),
+      licenses: licenses?.split(',').filter(id => !!id),
+    },
+    sortBy: sortBySearchOption,
+    sortOrder: sortOrder,
+  };
+
+  if (!options.sortBy || !options.sortOrder) {
+    const defaultSortMap = sortMapping[defaultSortBy];
+    options.sortBy = defaultSortMap.sortBy;
+    options.sortOrder = defaultSortMap.sortOrder;
+    sortByResponse = defaultSortBy;
+  }
+
+  if (isNaN(options.offset)) {
+    options.offset = 0;
+  }
+
+  const validOptions: SearchOptions = options;
+
+  // Only add a search query if provided
+  if (query) {
+    validOptions.query = query;
+  }
+
+  return {
+    searchOptions: validOptions,
+    sortBy: sortByResponse,
+  };
+}

--- a/src/lib/search-params.ts
+++ b/src/lib/search-params.ts
@@ -4,7 +4,7 @@ import {
   SortOrder,
   searchOptionsSchema,
 } from '@/lib/dataset-fetcher';
-import {any, z} from 'zod';
+import {z} from 'zod';
 
 export enum SortBy {
   RelevanceDesc = 'relevanceDesc',
@@ -86,7 +86,7 @@ export interface SearchParams {
 
 // Based on https://github.com/colinhacks/zod/issues/316#issuecomment-1024793482
 export function fallback<T>(value: T) {
-  return any().transform(() => value);
+  return z.any().transform(() => value);
 }
 
 // Always return a valid SearchOptions object, even if the search params aren't correct,
@@ -137,12 +137,12 @@ export function fromSearchParamsToSearchOptions({
   return validOptions;
 }
 
-interface sortPairProps {
+interface SortPairProps {
   sortBy: SortBySearchOption;
   sortOrder: SortOrder;
 }
 
-export function getClientSortBy(sortPair: sortPairProps): SortBy {
+export function getClientSortBy(sortPair: SortPairProps): SortBy {
   return Object.entries(sortMapping).find(
     ([, {sortBy, sortOrder}]) =>
       sortPair.sortBy === sortBy && sortPair.sortOrder === sortOrder


### PR DESCRIPTION
This will fix #163 

The search params were not set at all in the client filters.

I also renamed `sort` to `sortBy`. When using `useSearchParams`, the key `sort` is not allowed. Eventually, I did not use `useSearchParams` (client-side function) but went the server-side route. To keep it future-proof, I still kept the rename.