### PR TITLE
feat: dataset fetcher spatial coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,10 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 ### Create production build (for testing locally)
 
-First set the endpoint URLs in `.env`:
+Create the file `.env.production.local` in the root and set the endpoint URLs:
 
-```
-SEARCH_PLATFORM_ELASTIC_ENDPOINT_URL=
-SEARCH_PLATFORM_SPARQL_ENDPOINT_URL=
-```
+  SEARCH_PLATFORM_ELASTIC_ENDPOINT_URL=
+  SEARCH_PLATFORM_SPARQL_ENDPOINT_URL=
 
 Then run:
 
@@ -52,12 +50,10 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 ### Create production build (for testing locally)
 
-First set the endpoint URLs in `.env`:
+Create the file `.env.production.local` in the root and set the endpoint URLs:
 
-```
-SEARCH_PLATFORM_ELASTIC_ENDPOINT_URL=
-SEARCH_PLATFORM_SPARQL_ENDPOINT_URL=
-```
+  SEARCH_PLATFORM_ELASTIC_ENDPOINT_URL=
+  SEARCH_PLATFORM_SPARQL_ENDPOINT_URL=
 
 Then run:
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,12 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 ### Create production build (for testing locally)
 
-First append the Elasticsearch endpoint URL to `SEARCH_PLATFORM_ELASTIC_ENDPOINT_URL=` in `.env`.
+First set the endpoint URLs in `.env`:
+
+```
+SEARCH_PLATFORM_ELASTIC_ENDPOINT_URL=
+SEARCH_PLATFORM_SPARQL_ENDPOINT_URL=
+```
 
 Then run:
 
@@ -47,7 +52,12 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 ### Create production build (for testing locally)
 
-First append the Elasticsearch endpoint URL to `SEARCH_PLATFORM_ELASTIC_ENDPOINT_URL=` in `.env`.
+First set the endpoint URLs in `.env`:
+
+```
+SEARCH_PLATFORM_ELASTIC_ENDPOINT_URL=
+SEARCH_PLATFORM_SPARQL_ENDPOINT_URL=
+```
 
 Then run:
 

--- a/fixtures/search/create-search-graph.rq
+++ b/fixtures/search/create-search-graph.rq
@@ -14,10 +14,8 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 CONSTRUCT {
   ?dataset a cc:Dataset ;
     cc:name ?title ;
-    cc:publisherIri ?publisher ;
-    cc:publisherName ?publisherName ;
-    cc:licenseIri ?license ;
-    cc:licenseName ?licenseName ;
+    cc:publisher ?publisher ;
+    cc:license ?license ;
     cc:description ?description ;
     cc:keyword ?keyword ;
     cc:mainEntityOfPage ?landingPage ;
@@ -25,12 +23,19 @@ CONSTRUCT {
     cc:dateModified ?modified ;
     cc:datePublished ?issued ;
     cc:spatialCoverage ?place ;
+    cc:publisherName ?publisherName ; # To allow for search actions based on name
+    cc:licenseName ?licenseName ; # To allow for search actions based on name
     cc:placeName ?placeName ; # To allow for search actions based on name
     cc:placeName ?placeAlternateName . # To allow for search actions based on name
 
+  ?publisher a cc:Organization ;
+    cc:name ?publisherName .
+
+  ?license a cc:License ;
+    cc:name ?licenseName .
+
   ?place a cc:Place ;
-    cc:name ?placeName ;
-    cc:alternateName ?placeAlternateName .
+    cc:name ?placeName .
 }
 WHERE {
   ?dataset a dcat:Dataset .

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@types/react-dom": "18.0.11",
         "autoprefixer": "10.4.14",
         "cypress": "12.8.1",
+        "encoding": "^0.1.13",
         "eslint-config-next": "13.2.4",
         "gts": "3.1.1",
         "jest": "29.5.0",
@@ -3524,6 +3525,27 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "devOptional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "devOptional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -8570,7 +8592,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -12421,6 +12443,26 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "devOptional": true,
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "devOptional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -16052,7 +16094,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "devOptional": true
     },
     "saxes": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@types/react-dom": "18.0.11",
         "autoprefixer": "10.4.14",
         "cypress": "12.8.1",
-        "encoding": "^0.1.13",
+        "encoding": "0.1.13",
         "eslint-config-next": "13.2.4",
         "gts": "3.1.1",
         "jest": "29.5.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/react-dom": "18.0.11",
     "autoprefixer": "10.4.14",
     "cypress": "12.8.1",
-    "encoding": "^0.1.13",
+    "encoding": "0.1.13",
     "eslint-config-next": "13.2.4",
     "gts": "3.1.1",
     "jest": "29.5.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/react-dom": "18.0.11",
     "autoprefixer": "10.4.14",
     "cypress": "12.8.1",
+    "encoding": "^0.1.13",
     "eslint-config-next": "13.2.4",
     "gts": "3.1.1",
     "jest": "29.5.0",

--- a/src/lib/dataset-fetcher-instance.ts
+++ b/src/lib/dataset-fetcher-instance.ts
@@ -1,7 +1,14 @@
+import {LabelFetcher} from '@/lib/label-fetcher';
 import {DatasetFetcher} from '@/lib/dataset-fetcher/index';
+import {env} from 'node:process';
+
+const labelFetcher = new LabelFetcher({
+  endpointUrl: env.SEARCH_PLATFORM_SPARQL_ENDPOINT_URL as string,
+});
 
 const datasetFetcher = new DatasetFetcher({
-  endpointUrl: process.env.SEARCH_PLATFORM_ELASTIC_ENDPOINT_URL as string,
+  endpointUrl: env.SEARCH_PLATFORM_ELASTIC_ENDPOINT_URL as string,
+  labelFetcher,
 });
 
 export default datasetFetcher;

--- a/src/lib/dataset-fetcher/index.integration.test.ts
+++ b/src/lib/dataset-fetcher/index.integration.test.ts
@@ -1,12 +1,17 @@
 import {DatasetFetcher, SortBy, SortOrder} from '.';
+import {LabelFetcher} from '../label-fetcher';
 import {beforeEach, describe, expect, it} from '@jest/globals';
 import {env} from 'node:process';
 
+const labelFetcher = new LabelFetcher({
+  endpointUrl: env.SEARCH_PLATFORM_SPARQL_ENDPOINT_URL as string,
+});
 let datasetFetcher: DatasetFetcher;
 
 beforeEach(() => {
   datasetFetcher = new DatasetFetcher({
     endpointUrl: env.SEARCH_PLATFORM_ELASTIC_ENDPOINT_URL as string,
+    labelFetcher,
   });
 });
 
@@ -24,7 +29,10 @@ describe('search', () => {
         {
           id: 'https://example.org/datasets/1',
           name: 'Dataset 1',
-          publisher: {id: 'https://museum.example.org/', name: 'Museum'},
+          publisher: {
+            id: 'https://museum.example.org/',
+            name: 'Museum',
+          },
           license: {
             id: 'https://creativecommons.org/licenses/by/4.0/',
             name: 'Attribution 4.0 International (CC BY 4.0)',
@@ -36,11 +44,20 @@ describe('search', () => {
           dateCreated: new Date('2019-03-12T00:00:00.000Z'),
           dateModified: new Date('2023-02-17T00:00:00.000Z'),
           datePublished: new Date('2023-02-17T00:00:00.000Z'),
+          spatialCoverages: [
+            {
+              id: 'https://hdl.handle.net/20.500.11840/termmaster10063182',
+              name: 'Jakarta',
+            },
+          ],
         },
         {
           id: 'https://example.org/datasets/10',
           name: '(No name)',
-          publisher: {id: 'https://library.example.org/', name: 'Library'},
+          publisher: {
+            id: 'https://library.example.org/',
+            name: 'Library',
+          },
           license: {
             id: 'http://opendatacommons.org/licenses/by/1.0/',
             name: 'Open Data Commons Attribution License (ODC-By) v1.0',
@@ -49,17 +66,37 @@ describe('search', () => {
         {
           id: 'https://example.org/datasets/11',
           name: 'Dataset 11',
-          publisher: {id: 'https://library.example.org/', name: 'Library'},
+          publisher: {
+            id: 'https://library.example.org/',
+            name: 'Library',
+          },
           license: {
             id: 'https://creativecommons.org/publicdomain/zero/1.0/',
             name: 'CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
           },
           dateCreated: new Date('2019-03-12T00:00:00.000Z'),
+          spatialCoverages: [
+            {
+              id: 'https://hdl.handle.net/20.500.11840/termmaster10061190',
+              name: 'Indonesië',
+            },
+            {
+              id: 'https://hdl.handle.net/20.500.11840/termmaster10063351',
+              name: 'Bali',
+            },
+            {
+              id: 'https://hdl.handle.net/20.500.11840/termmaster10063401',
+              name: 'Ubud',
+            },
+          ],
         },
         {
           id: 'https://example.org/datasets/12',
           name: 'Dataset 12',
-          publisher: {id: 'https://library.example.org/', name: 'Library'},
+          publisher: {
+            id: 'https://library.example.org/',
+            name: 'Library',
+          },
           license: {
             id: 'https://creativecommons.org/publicdomain/zero/1.0/',
             name: 'CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
@@ -67,6 +104,16 @@ describe('search', () => {
           description:
             'Donec placerat orci vel erat commodo suscipit. Morbi elementum nunc ut dolor venenatis, vel ultricies nisi euismod. Sed aliquet ultricies sapien, vehicula malesuada nunc tristique ac.',
           keywords: ['Hendrerit', 'Vestibulum'],
+          spatialCoverages: [
+            {
+              id: 'https://hdl.handle.net/20.500.11840/termmaster10054875',
+              name: 'Ghana',
+            },
+            {
+              id: 'https://hdl.handle.net/20.500.11840/termmaster10055279',
+              name: 'Zuid-Afrika',
+            },
+          ],
         },
         {
           id: 'https://example.org/datasets/13',
@@ -83,11 +130,20 @@ describe('search', () => {
             'Cras erat elit, finibus eget ipsum vel, gravida dapibus leo. Etiam sem erat, suscipit id eros sit amet, scelerisque ornare sem. Aenean commodo elementum neque ac accumsan.',
           keywords: ['Fringilla'],
           dateCreated: new Date('2022-10-01T09:01:02.000Z'),
+          spatialCoverages: [
+            {
+              id: 'https://hdl.handle.net/20.500.11840/termmaster10058073',
+              name: 'Zuid-Amerika',
+            },
+          ],
         },
         {
           id: 'https://example.org/datasets/14',
           name: 'Dataset 14',
-          publisher: {id: 'https://library.example.org/', name: 'Library'},
+          publisher: {
+            id: 'https://library.example.org/',
+            name: 'Library',
+          },
           license: {
             id: 'http://creativecommons.org/publicdomain/zero/1.0/deed.nl',
             name: '(No name)',
@@ -99,7 +155,10 @@ describe('search', () => {
         {
           id: 'https://example.org/datasets/2',
           name: '(No name)',
-          publisher: {id: 'https://museum.example.org/', name: 'Museum'},
+          publisher: {
+            id: 'https://museum.example.org/',
+            name: 'Museum',
+          },
           license: {
             id: 'https://creativecommons.org/publicdomain/zero/1.0/',
             name: 'CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
@@ -107,11 +166,20 @@ describe('search', () => {
           dateCreated: new Date('2019-03-12T00:00:00.000Z'),
           dateModified: new Date('2023-02-17T00:00:00.000Z'),
           datePublished: new Date('2023-02-17T00:00:00.000Z'),
+          spatialCoverages: [
+            {
+              id: 'https://hdl.handle.net/20.500.11840/termmaster10055279',
+              name: 'Zuid-Afrika',
+            },
+          ],
         },
         {
           id: 'https://example.org/datasets/3',
           name: 'Dataset 3',
-          publisher: {id: 'https://archive.example.org/', name: 'Archive'},
+          publisher: {
+            id: 'https://archive.example.org/',
+            name: 'Archive',
+          },
           license: {
             id: 'http://opendatacommons.org/licenses/odbl/1.0/',
             name: 'Open Data Commons Open Database License (ODbL) v1.0',
@@ -120,7 +188,10 @@ describe('search', () => {
         {
           id: 'https://example.org/datasets/4',
           name: 'Dataset 4',
-          publisher: {id: 'https://museum.example.org/', name: 'Museum'},
+          publisher: {
+            id: 'https://museum.example.org/',
+            name: 'Museum',
+          },
           license: {
             id: 'http://opendatacommons.org/licenses/by/1.0/',
             name: 'Open Data Commons Attribution License (ODC-By) v1.0',
@@ -129,11 +200,20 @@ describe('search', () => {
             'Donec placerat orci vel erat commodo suscipit. Morbi elementum nunc ut dolor venenatis, vel ultricies nisi euismod. Sed aliquet ultricies sapien, vehicula malesuada nunc tristique ac.',
           keywords: ['Hendrerit', 'Suspendisse'],
           dateModified: new Date('2023-02-01T00:00:00.000Z'),
+          spatialCoverages: [
+            {
+              id: 'https://hdl.handle.net/20.500.11840/termmaster10058074',
+              name: 'Suriname',
+            },
+          ],
         },
         {
           id: 'https://example.org/datasets/5',
           name: 'Dataset 5',
-          publisher: {id: 'https://archive.example.org/', name: 'Archive'},
+          publisher: {
+            id: 'https://archive.example.org/',
+            name: 'Archive',
+          },
           license: {
             id: 'https://creativecommons.org/licenses/by/4.0/',
             name: 'Attribution 4.0 International (CC BY 4.0)',
@@ -145,9 +225,21 @@ describe('search', () => {
       ],
       filters: {
         publishers: [
-          {totalCount: 5, id: 'https://archive.example.org/', name: 'Archive'},
-          {totalCount: 5, id: 'https://library.example.org/', name: 'Library'},
-          {totalCount: 3, id: 'https://museum.example.org/', name: 'Museum'},
+          {
+            totalCount: 5,
+            id: 'https://archive.example.org/',
+            name: 'Archive',
+          },
+          {
+            totalCount: 5,
+            id: 'https://library.example.org/',
+            name: 'Library',
+          },
+          {
+            totalCount: 3,
+            id: 'https://museum.example.org/',
+            name: 'Museum',
+          },
           {
             totalCount: 1,
             id: 'https://research.example.org/',
@@ -184,6 +276,48 @@ describe('search', () => {
             totalCount: 1,
             id: 'http://rightsstatements.org/vocab/UND/1.0/',
             name: 'Copyright Undetermined',
+          },
+        ],
+        spatialCoverages: [
+          {
+            totalCount: 2,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10055279',
+            name: 'Zuid-Afrika',
+          },
+          {
+            totalCount: 2,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10058074',
+            name: 'Suriname',
+          },
+          {
+            totalCount: 2,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10063351',
+            name: 'Bali',
+          },
+          {
+            totalCount: 1,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10054875',
+            name: 'Ghana',
+          },
+          {
+            totalCount: 1,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10058073',
+            name: 'Zuid-Amerika',
+          },
+          {
+            totalCount: 1,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10061190',
+            name: 'Indonesië',
+          },
+          {
+            totalCount: 1,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10063182',
+            name: 'Jakarta',
+          },
+          {
+            totalCount: 1,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10063401',
+            name: 'Ubud',
           },
         ],
       },
@@ -243,6 +377,48 @@ describe('search', () => {
             totalCount: 0,
             id: 'http://rightsstatements.org/vocab/UND/1.0/',
             name: 'Copyright Undetermined',
+          },
+        ],
+        spatialCoverages: [
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10055279',
+            name: 'Zuid-Afrika',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10058074',
+            name: 'Suriname',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10063351',
+            name: 'Bali',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10054875',
+            name: 'Ghana',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10058073',
+            name: 'Zuid-Amerika',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10061190',
+            name: 'Indonesië',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10063182',
+            name: 'Jakarta',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10063401',
+            name: 'Ubud',
           },
         ],
       },
@@ -313,6 +489,48 @@ describe('search', () => {
             totalCount: 0,
             id: 'http://rightsstatements.org/vocab/UND/1.0/',
             name: 'Copyright Undetermined',
+          },
+        ],
+        spatialCoverages: [
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10055279',
+            name: 'Zuid-Afrika',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10058074',
+            name: 'Suriname',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10063351',
+            name: 'Bali',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10054875',
+            name: 'Ghana',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10058073',
+            name: 'Zuid-Amerika',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10061190',
+            name: 'Indonesië',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10063182',
+            name: 'Jakarta',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10063401',
+            name: 'Ubud',
           },
         ],
       },
@@ -464,6 +682,79 @@ describe('search', () => {
       },
     });
   });
+
+  it('finds datasets if "spatialCoverages" filter matches', async () => {
+    const result = await datasetFetcher.search({
+      filters: {
+        spatialCoverages: [
+          'https://hdl.handle.net/20.500.11840/termmaster10063182',
+        ],
+      },
+    });
+
+    expect(result).toMatchObject({
+      totalCount: 1,
+      offset: 0,
+      limit: 10,
+      sortBy: 'relevance',
+      sortOrder: 'desc',
+      datasets: [
+        {
+          id: 'https://example.org/datasets/1',
+          spatialCoverages: [
+            {
+              id: 'https://hdl.handle.net/20.500.11840/termmaster10063182',
+              name: 'Jakarta',
+            },
+          ],
+        },
+      ],
+      filters: {
+        spatialCoverages: [
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10055279',
+            name: 'Zuid-Afrika',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10058074',
+            name: 'Suriname',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10063351',
+            name: 'Bali',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10054875',
+            name: 'Ghana',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10058073',
+            name: 'Zuid-Amerika',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10061190',
+            name: 'Indonesië',
+          },
+          {
+            totalCount: 1,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10063182',
+            name: 'Jakarta',
+          },
+          {
+            totalCount: 0,
+            id: 'https://hdl.handle.net/20.500.11840/termmaster10063401',
+            name: 'Ubud',
+          },
+        ],
+      },
+    });
+  });
 });
 
 describe('getById', () => {
@@ -493,6 +784,12 @@ describe('getById', () => {
       dateCreated: new Date('2019-03-12T00:00:00.000Z'),
       dateModified: new Date('2023-02-17T00:00:00.000Z'),
       datePublished: new Date('2023-02-17T00:00:00.000Z'),
+      spatialCoverages: [
+        {
+          id: 'https://hdl.handle.net/20.500.11840/termmaster10063182',
+          name: 'Jakarta',
+        },
+      ],
     });
   });
 });

--- a/src/lib/dataset-fetcher/index.ts
+++ b/src/lib/dataset-fetcher/index.ts
@@ -27,9 +27,6 @@ enum RawDatasetKeys {
   SpatialCoverage = 'https://colonialcollections nl/search#spatialCoverage',
 }
 
-// For fetching the labels of IRIs, for display in filters
-const predicates = ['https://colonialcollections.nl/search#name'];
-
 type Thing = {
   id: string;
   name?: string; // Name may not exist (e.g. in a specific locale)
@@ -206,6 +203,7 @@ export class DatasetFetcher {
     // Extract the IRIs, if any, from the response.
     // The IRIs are necessary for fetching their labels later on
     const iris = getIrisFromObject(responseData);
+    const predicates = ['https://colonialcollections.nl/search#name'];
     await this.labelFetcher.loadByIris({iris, predicates});
 
     return responseData;

--- a/src/lib/dataset-fetcher/index.ts
+++ b/src/lib/dataset-fetcher/index.ts
@@ -153,11 +153,7 @@ type RawSearchResponseWithAggregations = z.infer<
   typeof rawSearchResponseWithAggregationsSchema
 >;
 
-export type SearchResultFilter = {
-  totalCount: number;
-  id: string;
-  name?: string; // Name may not exist (e.g. in a specific locale)
-};
+export type SearchResultFilter = Thing & {totalCount: number};
 
 export type SearchResult = {
   totalCount: number;

--- a/src/lib/dataset-fetcher/request.ts
+++ b/src/lib/dataset-fetcher/request.ts
@@ -1,9 +1,22 @@
-export function buildAggregation(id: string, name: string) {
+const size = 100; // TBD: what's a good size?
+
+export function buildMultiTermsAggregation(id: string, name: string) {
   const aggregation = {
     // Aggregate the hits by ID and name (for display)
     multi_terms: {
-      size: 100, // TBD: what's a good size?
+      size,
       terms: [{field: `${id}.keyword`}, {field: `${name}.keyword`}],
+    },
+  };
+
+  return aggregation;
+}
+
+export function buildSingleTermAggregation(id: string) {
+  const aggregation = {
+    terms: {
+      size,
+      field: `${id}.keyword`,
     },
   };
 

--- a/src/lib/dataset-fetcher/request.ts
+++ b/src/lib/dataset-fetcher/request.ts
@@ -1,21 +1,7 @@
-const size = 100; // TBD: what's a good size?
-
-export function buildMultiTermsAggregation(id: string, name: string) {
-  const aggregation = {
-    // Aggregate the hits by ID and name (for display)
-    multi_terms: {
-      size,
-      terms: [{field: `${id}.keyword`}, {field: `${name}.keyword`}],
-    },
-  };
-
-  return aggregation;
-}
-
-export function buildSingleTermAggregation(id: string) {
+export function buildAggregation(id: string) {
   const aggregation = {
     terms: {
-      size,
+      size: 100, // TBD: what's a good size?,
       field: `${id}.keyword`,
     },
   };

--- a/src/lib/dataset-fetcher/result.ts
+++ b/src/lib/dataset-fetcher/result.ts
@@ -6,15 +6,8 @@ function toUnmatchedFilter(
   labelFetcher: LabelFetcher
 ): SearchResultFilter {
   const totalCount = 0; // Initial count; will be overridden by the matching filter, if any
-
-  let id, name;
-  if (typeof bucket.key === 'string') {
-    id = bucket.key;
-    name = labelFetcher.getByIri({iri: id});
-  } else {
-    // Array
-    [id, name] = bucket.key;
-  }
+  const id = bucket.key;
+  const name = labelFetcher.getByIri({iri: id});
 
   return {totalCount, id, name};
 }
@@ -24,15 +17,8 @@ function toMatchedFilter(
   labelFetcher: LabelFetcher
 ): SearchResultFilter {
   const totalCount = bucket.doc_count; // Actual count if a filter matched the query
-
-  let id, name;
-  if (typeof bucket.key === 'string') {
-    id = bucket.key;
-    name = labelFetcher.getByIri({iri: id});
-  } else {
-    // Array
-    [id, name] = bucket.key;
-  }
+  const id = bucket.key;
+  const name = labelFetcher.getByIri({iri: id});
 
   return {totalCount, id, name};
 }

--- a/src/lib/dataset-fetcher/result.ts
+++ b/src/lib/dataset-fetcher/result.ts
@@ -1,14 +1,39 @@
 import type {RawBucket, SearchResultFilter} from '.';
+import {LabelFetcher} from '../label-fetcher';
 
-function toUnmatchedFilter(bucket: RawBucket): SearchResultFilter {
+function toUnmatchedFilter(
+  bucket: RawBucket,
+  labelFetcher: LabelFetcher
+): SearchResultFilter {
   const totalCount = 0; // Initial count; will be overridden by the matching filter, if any
-  const [id, name] = bucket.key;
+
+  let id, name;
+  if (typeof bucket.key === 'string') {
+    id = bucket.key;
+    name = labelFetcher.getByIri({iri: id});
+  } else {
+    // Array
+    [id, name] = bucket.key;
+  }
+
   return {totalCount, id, name};
 }
 
-function toMatchedFilter(bucket: RawBucket): SearchResultFilter {
+function toMatchedFilter(
+  bucket: RawBucket,
+  labelFetcher: LabelFetcher
+): SearchResultFilter {
   const totalCount = bucket.doc_count; // Actual count if a filter matched the query
-  const [id, name] = bucket.key;
+
+  let id, name;
+  if (typeof bucket.key === 'string') {
+    id = bucket.key;
+    name = labelFetcher.getByIri({iri: id});
+  } else {
+    // Array
+    [id, name] = bucket.key;
+  }
+
   return {totalCount, id, name};
 }
 
@@ -28,10 +53,15 @@ function combineUnmatchedWithMatchedFilters(
 
 export function buildFilters(
   rawUnmatchedFilters: RawBucket[],
-  rawMatchedFilters: RawBucket[]
+  rawMatchedFilters: RawBucket[],
+  labelFetcher: LabelFetcher
 ) {
-  const unmatchedFilters = rawUnmatchedFilters.map(toUnmatchedFilter);
-  const matchedFilters = rawMatchedFilters.map(toMatchedFilter);
+  const unmatchedFilters = rawUnmatchedFilters.map(rawUnmatchedFilter => {
+    return toUnmatchedFilter(rawUnmatchedFilter, labelFetcher);
+  });
+  const matchedFilters = rawMatchedFilters.map(rawMatchedFilter => {
+    return toMatchedFilter(rawMatchedFilter, labelFetcher);
+  });
   const combinedFilters = combineUnmatchedWithMatchedFilters(
     unmatchedFilters,
     matchedFilters

--- a/src/lib/iri.test.ts
+++ b/src/lib/iri.test.ts
@@ -5,6 +5,7 @@ describe('isIri', () => {
   it('returns true if input is a RFC 3987-compliant IRI', () => {
     expect(isIri('http://example.org')).toBe(true);
     expect(isIri('https://example.org')).toBe(true);
+    expect(isIri('https://example.org/?a[]=b')).toBe(true);
   });
 
   it('returns false if input is not a RFC 3987-compliant IRI', () => {
@@ -12,7 +13,6 @@ describe('isIri', () => {
     expect(isIri(null)).toBe(false);
     // @ts-expect-error:TS2345
     expect(isIri(1234)).toBe(false);
-    expect(isIri('https://example.org/?a[]=b')).toBe(false);
     expect(isIri('example.org')).toBe(false);
     expect(isIri('https://example.org/|')).toBe(false);
   });

--- a/src/lib/iri.ts
+++ b/src/lib/iri.ts
@@ -1,4 +1,4 @@
-import {validateIri} from 'validate-iri';
+import {validateIri, IriValidationStrategy} from 'validate-iri';
 import {z} from 'zod';
 
 export function isIri(value: string) {
@@ -6,7 +6,7 @@ export function isIri(value: string) {
     .string()
     // Zod's native url() validator is not RFC 3987-compliant
     .refine((arg: string) => {
-      const error = validateIri(arg);
+      const error = validateIri(arg, IriValidationStrategy.Pragmatic);
       return error === undefined;
     })
     .safeParse(value);

--- a/src/lib/label-fetcher.integration.test.ts
+++ b/src/lib/label-fetcher.integration.test.ts
@@ -9,7 +9,20 @@ const labelFetcher = new LabelFetcher({
 describe('getByIds', () => {
   it('returns undefined if IRIs have not been loaded', async () => {
     const label = labelFetcher.getByIri({
-      iri: 'http://www.wikidata.org/entity/Q33432813',
+      iri: 'http://www.wikidata.org/entity/Q727',
+    });
+
+    expect(label).toBeUndefined();
+  });
+
+  it('returns undefined if the provided predicate does not match', async () => {
+    await labelFetcher.loadByIris({
+      iris: ['http://www.wikidata.org/entity/Q727'],
+      predicates: ['http://www.w3.org/2004/02/skos/core#prefLabel'],
+    });
+
+    const label = labelFetcher.getByIri({
+      iri: 'http://www.wikidata.org/entity/Q727',
     });
 
     expect(label).toBeUndefined();
@@ -26,20 +39,7 @@ describe('getByIds', () => {
     expect(label).toBeUndefined();
   });
 
-  it('returns undefined if the provided predicate does not match', async () => {
-    await labelFetcher.loadByIris({
-      iris: ['http://www.wikidata.org/entity/Q33432813'],
-      predicates: ['http://www.w3.org/2004/02/skos/core#prefLabel'],
-    });
-
-    const label = labelFetcher.getByIri({
-      iri: 'http://www.wikidata.org/entity/Q33432813',
-    });
-
-    expect(label).toBeUndefined();
-  });
-
-  it('gets the label of the provided IRI', async () => {
+  it('returns the label of the provided IRI', async () => {
     await labelFetcher.loadByIris({
       iris: ['http://www.wikidata.org/entity/Q33432813'],
       predicates: ['http://www.w3.org/2000/01/rdf-schema#label'],


### PR DESCRIPTION
This PR adds support for the dataset property 'spatial coverage'. This property contains the ID and name of the places/locations that a dataset is about. We can use the property for display on the detail page and as a filter on the search page. The PR is part of issue #113 .

The PR introduces quite a number of changes. The interface to Next, however, is largely unchanged. If I'm not mistaken the only backward incompatible change is the `name` property of publishers and licenses: the name now can be `undefined` (because it's not always known; see https://github.com/colonial-heritage/dataset-browser/blob/feat-dataset-fetcher-spatial-coverage/src/lib/dataset-fetcher/index.ts#L35).

Please do not merge the PR after approval: I have to make a change to the Elasticsearch indexing first.