### PR TITLE
Remove global styles and use @tailwindcss/typography

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       "devDependencies": {
         "@jest/globals": "29.5.0",
         "@next/env": "13.2.4",
-        "@tailwindcss/typography": "^0.5.9",
+        "@tailwindcss/typography": "0.5.9",
         "@types/mdx": "2.0.3",
         "@types/node": "18.15.11",
         "@types/react": "18.0.32",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       "devDependencies": {
         "@jest/globals": "29.5.0",
         "@next/env": "13.2.4",
+        "@tailwindcss/typography": "^0.5.9",
         "@types/mdx": "2.0.3",
         "@types/node": "18.15.11",
         "@types/react": "18.0.32",
@@ -1877,6 +1878,34 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.9.tgz",
+      "integrity": "sha512-t8Sg3DyynFysV9f4JDOVISGsjazNb48AeIYQwcL+Bsq5uf4RYL75C1giZ43KISjeDGBaTN3Kxh7Xj/vRSMJUUg==",
+      "dev": true,
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@types/babel__core": {
@@ -7191,6 +7220,18 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -11654,6 +11695,30 @@
         "mini-svg-data-uri": "^1.2.3"
       }
     },
+    "@tailwindcss/typography": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.9.tgz",
+      "integrity": "sha512-t8Sg3DyynFysV9f4JDOVISGsjazNb48AeIYQwcL+Bsq5uf4RYL75C1giZ43KISjeDGBaTN3Kxh7Xj/vRSMJUUg==",
+      "dev": true,
+      "requires": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "6.0.10",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+          "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        }
+      }
+    },
     "@types/babel__core": {
       "version": "7.20.0",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
@@ -15588,6 +15653,18 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true
     },
     "lodash.merge": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@jest/globals": "29.5.0",
     "@next/env": "13.2.4",
-    "@tailwindcss/typography": "^0.5.9",
+    "@tailwindcss/typography": "0.5.9",
     "@types/mdx": "2.0.3",
     "@types/node": "18.15.11",
     "@types/react": "18.0.32",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@jest/globals": "29.5.0",
     "@next/env": "13.2.4",
+    "@tailwindcss/typography": "^0.5.9",
     "@types/mdx": "2.0.3",
     "@types/node": "18.15.11",
     "@types/react": "18.0.32",

--- a/src/app/[locale]/globals.css
+++ b/src/app/[locale]/globals.css
@@ -1,34 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@layer base {
-  h1 {
-    @apply text-2xl;
-    @apply font-semibold;
-    @apply pb-10;
-  }
-  h2 {
-    @apply text-xl;
-    @apply font-semibold;
-    @apply mb-1;
-    @apply mt-10;
-  }
-  h3 {
-    @apply text-lg;
-    @apply font-semibold;
-    @apply mb-2;
-    }
-  p {
-    @apply mb-4;
-  }
-  a {
-    @apply text-sky-700;
-  }
-  ul {
-    @apply list-disc;
-  }
-  li {
-    @apply ml-4;
-  }
-}

--- a/src/components/localized-markdown.tsx
+++ b/src/components/localized-markdown.tsx
@@ -1,16 +1,25 @@
 import {useLocale} from 'next-intl';
 import {notFound} from 'next/navigation';
+import classNames from 'classnames';
 
 interface Props {
   name: string;
 }
 
 async function LocalizedMarkdown({name}: Props) {
+  const markdownClassName = classNames(
+    'max-w-3xl prose',
+    'prose-headings:font-semibold prose:text-blue-100',
+    'prose-h1:text-2xl prose-h1:mb-10',
+    'prose-h2:text-xl prose-h2:mb-1 prose-h2:mt-10',
+    'prose-h3:text-lg prose-h3:mb-2',
+    'prose-a:text-sky-700 prose-a:no-underline'
+  );
   const locale = useLocale();
   try {
     const Markdown = (await import(`@/messages/${locale}/${name}.mdx`)).default;
     return (
-      <div className="max-w-3xl">
+      <div className={markdownClassName}>
         <Markdown />
       </div>
     );

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -1,17 +1,5 @@
 import type {MDXComponents} from 'mdx/types';
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
-  return {
-    h1: ({children}) => (
-      <h1 className="leading-tight tracking-tight text-gray-900">{children}</h1>
-    ),
-    h2: ({children}) => (
-      <h2 className="leading-tight tracking-tight text-gray-900">{children}</h2>
-    ),
-    h3: ({children}) => (
-      <h3 className="leading-tight tracking-tight text-gray-900">{children}</h3>
-    ),
-    p: ({children}) => <p className="text-gray-900">{children}</p>,
-    ...components,
-  };
+  return components;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,13 @@ module.exports = {
   ],
   theme: {
     extend: {
+      typography: theme => ({
+        DEFAULT: {
+          css: {
+            color: theme('colors.gray.900'),
+          },
+        },
+      }),
       colors: {
         gray: {
           light: '#F7F5F2',
@@ -17,5 +24,5 @@ module.exports = {
       },
     },
   },
-  plugins: [require('@tailwindcss/forms')],
+  plugins: [require('@tailwindcss/forms'), require('@tailwindcss/typography')],
 };


### PR DESCRIPTION
The global styles have side effects, I have found two bugs, but it could be more.

- https://github.com/colonial-heritage/dataset-browser/issues/182
- https://github.com/colonial-heritage/dataset-browser/issues/181


I've only included the global styles that I think are necessary. So please compare the current and new versions and indicate if some styles need to be added/adjusted.

current version: https://dev.app.colonialcollections.nl/about
New version: https://dataset-browser-git-no-global-styles-colonial-heritage.vercel.app/about